### PR TITLE
Remove ping command

### DIFF
--- a/main.py
+++ b/main.py
@@ -308,10 +308,6 @@ async def _post_all_activity_boards():
 # Slash Commands
 # ---------------------------
 
-@bot.tree.command(name="ping", description="Check bot latency")
-async def ping(interaction: discord.Interaction):
-    await interaction.response.send_message(f"Pong! {round(bot.latency * 1000)} ms")
-
 @bot.tree.command(name="join", description="Join an activity queue")
 @app_commands.describe(activity="Choose an activity to join")
 @app_commands.autocomplete(activity=_activity_autocomplete)


### PR DESCRIPTION
Remove the `/ping` slash command as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fb9fd5a-dfd8-4984-89b3-e465a6326719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fb9fd5a-dfd8-4984-89b3-e465a6326719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

