### PR TITLE
Debug main.py for optimal performance

### DIFF
--- a/main.py
+++ b/main.py
@@ -317,7 +317,8 @@ async def ping(interaction: discord.Interaction):
 @app_commands.autocomplete(activity=_activity_autocomplete)
 async def join_cmd(interaction: discord.Interaction, activity: str):
     member = interaction.user if isinstance(interaction.user, discord.Member) else None
-    if member and _is_sherpa(member):
+    # Only block Sherpa Assistants from joining queues (full Sherpas may join)
+    if member and _is_sherpa_assistant(member):
         await interaction.response.send_message("Sherpa Assistants cannot join queues.", ephemeral=True)
         return
     if activity not in ALL_ACTIVITIES:


### PR DESCRIPTION
Fix `join_cmd` to only block Sherpa Assistants from joining queues.

Previously, the `join_cmd` incorrectly blocked all users with the `_is_sherpa` role from joining queues. This change modifies the condition to specifically check for `_is_sherpa_assistant`, allowing full Sherpas to join as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-38250557-3341-4aed-aa8e-d6a21c696f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38250557-3341-4aed-aa8e-d6a21c696f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

