### PR TITLE
Fix syntax error in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1189,27 +1189,6 @@ async def on_message_delete(message: discord.Message):
         new_msg = await _send_to_channel_id(int(ch_id), embed=embed, file=f)
         if not new_msg:
             return
-<<<<<<< HEAD
-        # Re-add standard reactions depending on type
-        if str(data.get("type")) == "sherpa_only":
-            for emoji in ("✅", "🔁", "❌"):
-                try:
-                    await new_msg.add_reaction(emoji)
-                except Exception:
-                    pass
-        else:
-            for emoji in ("📝", "❌"):
-                try:
-                    await new_msg.add_reaction(emoji)
-                except Exception:
-                    pass
-        # Persist rehosted image URL if present on restored embed
-        try:
-            if new_msg.embeds and new_msg.embeds[0].image and new_msg.embeds[0].image.url:
-                data["image_url"] = new_msg.embeds[0].image.url
-        except Exception:
-            pass
-=======
         # Re-add standard reactions depending on type
         if str(data.get("type")) == "sherpa_only":
             for emoji in ("✅", "🔁", "❌"):
@@ -1223,7 +1202,12 @@ async def on_message_delete(message: discord.Message):
                     await new_msg.add_reaction(emoji)
                 except Exception:
                     pass
->>>>>>> cursor/explain-the-event-command-5de3
+        # Persist rehosted image URL if present on restored embed
+        try:
+            if new_msg.embeds and new_msg.embeds[0].image and new_msg.embeds[0].image.url:
+                data["image_url"] = new_msg.embeds[0].image.url
+        except Exception:
+            pass
         # Update schedule mapping to include the new message id while preserving the old for DM callbacks
         new_mid = int(new_msg.id)
         SCHEDULES[new_mid] = data


### PR DESCRIPTION
Resolve a merge conflict in `main.py` to fix a `SyntaxError: invalid decimal literal`.

The `SyntaxError` was caused by unresolved merge conflict markers in the `on_message_delete` function. This PR resolves the conflict by combining the logic for adding reactions for both sherpa-only and non-sherpa events, and preserving the image URL persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-13e9b7f6-250c-47dd-8122-1a73363a28d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13e9b7f6-250c-47dd-8122-1a73363a28d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

