### PR TITLE
Fix promotion command and add auto message

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,3 +10,5 @@ services:
     envVars:
       - key: DISCORD_TOKEN
         sync: false
+      - key: FOUNDER_USER_ID
+        value: "606274733750878218"


### PR DESCRIPTION
Refactor `/promote` command to auto-detect events, remove `message_id` parameter, always post an announcement, and set the founder ID for permission checks.

The user requested these changes to streamline the promotion process, remove manual message ID input, ensure automatic announcements, and establish specific permission for the founder.

---
<a href="https://cursor.com/background-agent?bcId=bc-f791a051-4a62-4df7-8a03-647ef363f268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f791a051-4a62-4df7-8a03-647ef363f268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

