### PR TITLE
Link desert perpetual raid image to activities

### DIFF
--- a/main.py
+++ b/main.py
@@ -331,7 +331,7 @@ def _apply_activity_image(embed: discord.Embed, activity: str) -> Tuple[discord.
     # Known fallbacks for newer activities that may not exist in assets yet
     # Map canonicalized activity names -> local asset path (temporary placeholder)
     FALLBACK_LOCAL_IMAGES = {
-        "desert perpetual": os.path.join(os.path.dirname(__file__), "assets", "raids", "salvations_edge.jpg"),
+        "desert perpetual": os.path.join(os.path.dirname(__file__), "assets", "raids", "Desert_Perpetual.jpeg"),
     }
 
     img = _find_activity_image(activity)


### PR DESCRIPTION
Update the fallback image for "desert perpetual" to display the correct `Desert_Perpetual.jpeg` asset in embeds.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf15f07f-4e21-468b-8068-636eb59bdd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf15f07f-4e21-468b-8068-636eb59bdd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

