### PR TITLE
Fix user promotion bug

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,3 +12,5 @@ services:
         sync: false
       - key: FOUNDER_USER_ID
         value: "606274733750878218"
+      - key: SHERPA_ASSISTANT_ROLE_ID
+        value: "1278022068591530085"


### PR DESCRIPTION
Defer `/promote` interaction and add robust role assignment with detailed error feedback to prevent timeouts and silent failures.

The `/promote` command was timing out, displaying "application did not respond," and silently failing to assign roles without user feedback. This PR addresses these issues by immediately deferring the interaction, improving member fetching, and implementing comprehensive checks for permissions, role hierarchy, and configuration, providing clear ephemeral messages on success or failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef23649b-621b-4b00-9a52-1b3b69da7e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef23649b-621b-4b00-9a52-1b3b69da7e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

