### PR TITLE
Dungeon request equilibrium

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -21,7 +21,8 @@
   "\ud83d\udc7b Ghost of the Deep \ud83d\udc7b",
     "\u2694\ufe0f Warlord's Ruin \u2694\ufe0f",
     "\u2600\ufe0f Sunder Doctrine \u2600\ufe0f",
-    "\ud83d\udef0\ufe0f Vesper Host \ud83d\udef0\ufe0f"
+    "\ud83d\udef0\ufe0f Vesper Host \ud83d\udef0\ufe0f",
+    "\u2696\ufe0f Equilibrium \u2696\ufe0f"
   ],
   "exotic_activities": [
     "\ud83c\udf0c The Whisper \ud83c\udf0c",


### PR DESCRIPTION
Add 'Equilibrium' to the dungeon presets list in `activities.json` as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-b63d9c00-c251-4f8c-9eb7-06ba37fd10cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b63d9c00-c251-4f8c-9eb7-06ba37fd10cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new dungeon entry to enable selection/use in features consuming `activities.json`.
> 
> - Appends `"\u2696\ufe0f Equilibrium \u2696\ufe0f"` to the `dungeons` array in `activities.json`
> - Minor formatting tweak: trailing comma after `"\ud83d\udef0\ufe0f Vesper Host \ud83d\udef0\ufe0f"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79b4f85e9f025a8c0250b2b9de3d0ceb6214ea58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->