### PR TITLE
Schedule command late join

### DIFF
--- a/main.py
+++ b/main.py
@@ -2403,6 +2403,10 @@ class ConfirmView(discord.ui.View):
         backups: List[int] = data.get("backups", [])  # type: ignore
         cap = int(data.get("capacity", 0)); reserved = int(data.get("reserved_sherpas", 0))
         player_slots = max(0, cap - reserved)
+        # Late-join cutoff: within 2 hours of start, queued users cannot bump a full roster
+        start_ts = int(data.get("start_ts") or 0)
+        now_ts = int(datetime.utcnow().timestamp())
+        late_full_window = bool(start_ts) and now_ts >= start_ts - 2 * 60 * 60
         # Queue prioritization: users who were in the queue when scheduled are prioritized
         candidates: List[int] = data.get("candidates", []) or []  # type: ignore
         promoter_id: Optional[int] = data.get("promoter_id")  # type: ignore
@@ -2435,6 +2439,13 @@ class ConfirmView(discord.ui.View):
         else:
             # If roster is full but the confirmer is prioritized (queued), try to bump a non-queued participant
             if is_prioritized:
+                if late_full_window:
+                    await interaction.response.send_message(
+                        "Sorry, the roster is full and we're within 2 hours of start. You're still in the queue.",
+                        ephemeral=True,
+                    )
+                    _log_confirmation(self.mid, self.uid, "confirm", "late_full")
+                    return
                 # Find a participant who is NOT in the queued candidate list and is not the promoter
                 bumpable_indices: List[int] = [
                     idx for idx, uid in enumerate(list(participants))

--- a/main.py
+++ b/main.py
@@ -2441,7 +2441,9 @@ class ConfirmView(discord.ui.View):
             if is_prioritized:
                 if late_full_window:
                     await interaction.response.send_message(
-                        "Sorry, the roster is full and we're within 2 hours of start. You're still in the queue.",
+                        "I'm so sorry—you were too late for this one. "
+                        "If the roster is full, we lock it 2 hours before start so no more bumps happen. "
+                        "You're still in the queue though, and you can try again for the next run.",
                         ephemeral=True,
                     )
                     _log_confirmation(self.mid, self.uid, "confirm", "late_full")


### PR DESCRIPTION
Add a 2-hour cutoff for queued confirmations to prevent bumping a full roster close to event start.

---
<a href="https://cursor.com/background-agent?bcId=bc-15bf6294-fc4e-4c40-944f-e849953e2d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15bf6294-fc4e-4c40-944f-e849953e2d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a late-join cutoff to stabilize rosters close to start time.
> 
> - In `ConfirmView.yes`, compute `late_full_window` from `start_ts` and current time; if roster is full and user is prioritized within 2 hours of start, block bumping and send an explanatory DM
> - Log outcome with `_log_confirmation(..., "late_full")`; otherwise existing bump/backup logic remains unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fef571c587bd53b95e05330a34798265920d200. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->