### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+GoonBot is a Destiny 2 Discord bot built with Python and `discord.py`. It is a single-file application (`main.py`, ~5100 lines) with two helper modules (`env_safety.py`, `presets_loader.py`). There is no database — all persistent state is stored as flat JSON files in `./data/`.
+
+### Running the bot
+
+- **Start command:** `python main.py`
+- **Required secret:** `DISCORD_TOKEN` environment variable (a valid Discord bot token). The bot will crash immediately without it.
+- The bot reads channel/role IDs from environment variables and falls back to `channel_ids.json`.
+
+### Dependencies
+
+- Single pip dependency: `discord.py` (see `requirements.txt`)
+- Python 3.9+ required (uses `zoneinfo` from stdlib)
+- Install: `pip install -r requirements.txt`
+
+### Linting
+
+- No linter is configured in the repo. Use `python3 -m pyflakes *.py` for basic checks.
+- There are 4 pre-existing pyflakes warnings in `main.py` (unused variables, f-string issue, undefined `msg_id`).
+
+### Testing
+
+- No automated test suite exists. Verify changes via `python3 -m py_compile main.py` and full module import test.
+- For end-to-end testing, a valid `DISCORD_TOKEN` and a Discord test server are required.
+
+### Key gotchas
+
+- `main.py` is very large (~5100 lines, ~218KB). Reading the full file may exceed tool limits; use offset/limit or search.
+- The `data/` directory is auto-created at module load time. JSON state files are created lazily on first write.
+- The bot uses `discord.py` slash commands (`app_commands`), not legacy prefix commands.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on GoonBot.

### What's included

- **Project overview**: Single-file Discord bot (`main.py`, ~5100 lines) with `discord.py`, no database
- **Run instructions**: `python main.py` with `DISCORD_TOKEN` env var
- **Dependency info**: Single pip dependency (`discord.py`), Python 3.9+
- **Lint guidance**: `python3 -m pyflakes *.py` (no linter pre-configured)
- **Testing notes**: No automated test suite; compile check + module import for basic verification
- **Key gotchas**: Large main.py file size, auto-created `data/` dir, slash commands only

### Environment verification

Full environment verification log showing all checks pass:

[env_verification.log](https://cursor.com/agents/bc-2691bb92-5812-4e13-96d3-65489a34a6ca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_verification.log)

All 3 Python files compile, all 19 slash commands register, presets load correctly, and the bot reaches the Discord API login step (blocked only by missing token).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2691bb92-5812-4e13-96d3-65489a34a6ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2691bb92-5812-4e13-96d3-65489a34a6ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

