### PR TITLE
Expand auto-help replies and add GFerry reminder footer

### DIFF
--- a/main.py
+++ b/main.py
@@ -469,10 +469,14 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
     def has_any(*phrases: str) -> bool:
         return any(p in text for p in phrases)
 
+    def with_footer(reply_text: str) -> str:
+        return reply_text.rstrip() + "\n\nDon't forget to message @GFerryGoon."
+
     has_question_tone = ("?" in text) or text.startswith(
         ("how ", "where ", "what ", "can ", "do ", "is ", "are ", "when ", "which ", "who ", "why ", "help")
     )
     asks_signup = has_any("sign up", "signup", "join", "register", "queue", "lfg")
+    asks_join_raid = has_any("how do i join a raid", "join raid", "join a raid")
     asks_where = has_any("where", "which channel", "what channel")
     asks_leave = has_any("leave", "cancel", "drop", "remove me", "step out")
     asks_commands = has_any("commands", "command", "slash", "bot command", "how to use bot")
@@ -492,7 +496,7 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
     lfg_channel = _channel_mention_or_fallback(LFG_CHAT_CHANNEL_ID, "#lfg")
 
     if asks_commands and activity_context:
-        return (
+        return with_footer(
             "Common commands:\n"
             "• **/join** — join an activity queue\n"
             "• **/queue** — view current queues\n"
@@ -502,8 +506,16 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "If you’re unsure, ask your question and I’ll point you to the right command."
         )
 
+    if asks_join_raid:
+        return with_footer(
+            "To join a raid:\n"
+            "1) Use **/join** and select the raid.\n"
+            f"2) Use **/queue** to check your place (or watch {queue_channel}).\n"
+            f"3) Watch {signup_channel} and react **✅** when your run is posted."
+        )
+
     if asks_signup and raid_or_dungeon:
-        return (
+        return with_footer(
             "For raid/dungeon signups:\n"
             "1) Use **/join** and pick the activity.\n"
             f"2) Check your spot with **/queue** (or watch {queue_channel}).\n"
@@ -512,16 +524,16 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
         )
 
     if asks_queue_spot and activity_context:
-        return f"Use **/queue** to see your current position. Queue boards are posted in {queue_channel}."
+        return with_footer(f"Use **/queue** to see your current position. Queue boards are posted in {queue_channel}.")
 
     if asks_where and any(k in text for k in ("sign", "join", "event", "raid", "dungeon")):
-        return (
+        return with_footer(
             f"Raid and dungeon events are posted in {signup_channel}, and chat/LFG updates happen in {lfg_channel}. "
             "Use **/join** to enter the queue, then **/queue** to see your position."
         )
 
     if asks_reactions and activity_context:
-        return (
+        return with_footer(
             "Reaction guide on event posts:\n"
             "• **✅** = join if a slot is open\n"
             "• **🔁** = backup/waitlist\n"
@@ -530,16 +542,16 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
         )
 
     if asks_leave and any(k in text for k in ("raid", "dungeon", "queue", "run", "signup")):
-        return "Use **/leave** to step out of a raid/dungeon queue or signup."
+        return with_footer("Use **/leave** to step out of a raid/dungeon queue or signup.")
 
     if asks_sherpa and activity_context:
-        return (
+        return with_footer(
             "New/learning runs are welcome. Join with **/join**, then watch event posts in "
             f"{signup_channel}. If Sherpas are needed, those runs will call it out in {lfg_channel}."
         )
 
     if asks_hosting and activity_context:
-        return (
+        return with_footer(
             "To host, use:\n"
             "• **/event** for normal player signups\n"
             "• **/event_sherpa** for Sherpa-only signups\n"
@@ -547,14 +559,15 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
         )
 
     if asks_time and activity_context:
-        return (
+        return with_footer(
             f"Event posts in {signup_channel} include the scheduled time. "
             "You’ll also get reminders before start when applicable."
         )
 
     if has_question_tone and (activity_context or direct_bot_question):
-        return (
+        return with_footer(
             "I can help with raid/dungeon/LFG questions. Try asking:\n"
+            "• **How do I join a raid?**\n"
             "• **How do I sign up for raids?**\n"
             "• **Where are event posts?**\n"
             "• **How do I check queue position?**\n"

--- a/main.py
+++ b/main.py
@@ -146,6 +146,9 @@ COOLDOWNS: Dict[str, Dict[int, int]] = {}
 HELP_REPLY_LAST_SENT: Dict[Tuple[int, int], int] = {}
 HELP_REPLY_COOLDOWN_SECONDS = 20
 _ACTIVITY_ALIAS_CACHE: Optional[Dict[str, str]] = None
+HELP_QUEUE_CONFIRM_PENDING: Dict[Tuple[int, int], Dict[str, object]] = {}
+HELP_QUEUE_CONFIRM_TTL_SECONDS = 180
+HELP_REMINDER_FOOTER = "Don't forget to message @GFerryGoon."
 
 # ---------------------------
 # External Helpers (project)
@@ -540,16 +543,178 @@ def _extract_activity_from_help_text(message_text: str) -> Tuple[Optional[str], 
             return act, True
     return None, False
 
-def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) -> Optional[str]:
+def _set_help_queue_confirm(channel_id: int, user_id: int, activity: str) -> None:
+    try:
+        now = int(datetime.utcnow().timestamp())
+        HELP_QUEUE_CONFIRM_PENDING[(int(channel_id), int(user_id))] = {
+            "activity": str(activity),
+            "expires_at": now + int(HELP_QUEUE_CONFIRM_TTL_SECONDS),
+        }
+        # Keep pending confirmations bounded.
+        if len(HELP_QUEUE_CONFIRM_PENDING) > 3000:
+            for key, data in list(HELP_QUEUE_CONFIRM_PENDING.items()):
+                try:
+                    if int(data.get("expires_at", 0) or 0) < now:
+                        HELP_QUEUE_CONFIRM_PENDING.pop(key, None)
+                except Exception:
+                    HELP_QUEUE_CONFIRM_PENDING.pop(key, None)
+    except Exception:
+        pass
+
+def _get_help_queue_confirm(channel_id: int, user_id: int) -> Optional[str]:
+    try:
+        now = int(datetime.utcnow().timestamp())
+        data = HELP_QUEUE_CONFIRM_PENDING.get((int(channel_id), int(user_id)))
+        if not data:
+            return None
+        expires_at = int(data.get("expires_at", 0) or 0)
+        if expires_at and now > expires_at:
+            HELP_QUEUE_CONFIRM_PENDING.pop((int(channel_id), int(user_id)), None)
+            return None
+        activity = str(data.get("activity") or "").strip()
+        return activity or None
+    except Exception:
+        return None
+
+def _clear_help_queue_confirm(channel_id: int, user_id: int) -> None:
+    try:
+        HELP_QUEUE_CONFIRM_PENDING.pop((int(channel_id), int(user_id)), None)
+    except Exception:
+        pass
+
+def _is_affirmative_help_reply(message_text: str) -> bool:
+    txt = _normalize_activity_text(message_text or "")
+    if not txt:
+        return False
+    affirm_set = {
+        "y", "yes", "yea", "yeah", "yep", "yup", "ok", "okay", "sure", "please",
+        "do it", "go ahead", "sounds good", "for sure", "affirmative",
+    }
+    if txt in affirm_set:
+        return True
+    return txt.startswith(("yes ", "yeah ", "yep ", "ok ", "okay ", "sure "))
+
+def _is_negative_help_reply(message_text: str) -> bool:
+    txt = _normalize_activity_text(message_text or "")
+    if not txt:
+        return False
+    negative_set = {
+        "n", "no", "nah", "nope", "not now", "cancel", "stop", "never mind",
+    }
+    if txt in negative_set:
+        return True
+    return txt.startswith(("no ", "nah ", "nope ", "not now "))
+
+async def _reply_queue_confirmation_embed(
+    message: discord.Message,
+    *,
+    activity: str,
+    status: str,
+    details: str,
+    success: bool,
+) -> None:
+    embed = discord.Embed(
+        title="Queue Confirmation",
+        description=details,
+        color=(0x57F287 if success else 0xED4245),
+    )
+    embed.add_field(name="Activity", value=activity, inline=True)
+    embed.add_field(name="Status", value=status, inline=True)
+    embed.set_footer(text=HELP_REMINDER_FOOTER)
+    await message.reply(embed=embed, mention_author=False)
+
+async def _join_queue_from_help_confirmation(message: discord.Message, activity: str) -> None:
+    member = message.author if isinstance(message.author, discord.Member) else None
+    uid = int(message.author.id)
+
+    # Queue is for players; Sherpas and Assistants use Sherpa signup posts.
+    if member and (_is_sherpa(member) or _is_sherpa_assistant(member)):
+        await _reply_queue_confirmation_embed(
+            message,
+            activity=activity,
+            status="Not Added",
+            details="Sherpas and Sherpa Assistants cannot join player queues.",
+            success=False,
+        )
+        return
+
+    act, _ = _resolve_activity(activity, list(ALL_ACTIVITIES) + list(QUEUES.keys()))
+    if not act:
+        await _reply_queue_confirmation_embed(
+            message,
+            activity=activity,
+            status="Not Added",
+            details="I couldn't find that activity queue. Try `/join` and pick from autocomplete.",
+            success=False,
+        )
+        return
+
+    # Enforce per-activity cooldown.
+    try:
+        now = int(datetime.utcnow().timestamp())
+        cd_map = COOLDOWNS.get(act, {})
+        until = int(cd_map.get(uid, 0) or 0)
+        if until and now < until:
+            remaining = until - now
+            hrs = max(1, int((remaining + 3599) // 3600))
+            await _reply_queue_confirmation_embed(
+                message,
+                activity=act,
+                status="Cooldown Active",
+                details=f"You can rejoin **{act}** in about {hrs} hour(s).",
+                success=False,
+            )
+            return
+    except Exception:
+        pass
+
+    in_any = [a for a, lst in QUEUES.items() if uid in lst]
+    q = _ensure_queue(act)
+    if act in in_any:
+        pos = q.index(uid) + 1 if uid in q else len(q)
+        await _reply_queue_confirmation_embed(
+            message,
+            activity=act,
+            status="Already Queued",
+            details=f"You're already in the queue at position **#{pos}** ({len(q)} total).",
+            success=True,
+        )
+        return
+
+    if len(in_any) >= 2:
+        await _reply_queue_confirmation_embed(
+            message,
+            activity=act,
+            status="Queue Limit Reached",
+            details="You can be in at most **2** different activity queues at a time.",
+            success=False,
+        )
+        return
+
+    q.append(uid)
+    _ensure_catty(act).discard(uid)
+    await persist_queues()
+    await persist_catty()
+    pos = q.index(uid) + 1
+    await _post_activity_board(act)
+    await _reply_queue_confirmation_embed(
+        message,
+        activity=act,
+        status="Added to Queue",
+        details=f"You're signed up for **{act}** at position **#{pos}** ({len(q)} total).",
+        success=True,
+    )
+
+def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) -> Tuple[Optional[str], Optional[str]]:
     text = " ".join((message_text or "").lower().split())
     if not text:
-        return None
+        return None, None
 
     def has_any(*phrases: str) -> bool:
         return any(p in text for p in phrases)
 
     def with_footer(reply_text: str) -> str:
-        return reply_text.rstrip() + "\n\nDon't forget to message @GFerryGoon."
+        return reply_text.rstrip() + f"\n\n{HELP_REMINDER_FOOTER}"
 
     has_question_tone = ("?" in text) or text.startswith(
         ("how ", "where ", "what ", "can ", "do ", "is ", "are ", "when ", "which ", "who ", "why ", "help")
@@ -585,7 +750,7 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "• **/event** — create a player event signup\n"
             "• **/event_sherpa** — create a Sherpa-only signup\n"
             "If you’re unsure, ask your question and I’ll point you to the right command."
-        )
+        ), None
 
     if asks_join_raid:
         return with_footer(
@@ -593,7 +758,7 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "1) Use **/join** and select the raid.\n"
             f"2) Use **/queue** to check your place (or watch {queue_channel}).\n"
             f"3) Watch {signup_channel} and react **✅** when your run is posted."
-        )
+        ), None
 
     if asks_how_to_join and mentioned_activity and _is_raid_or_dungeon(mentioned_activity):
         alias_hint = " (recognized from abbreviation)" if matched_by_alias else ""
@@ -601,14 +766,14 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             f"I see **{mentioned_activity}**{alias_hint}. Do you want to be signed up for that queue?\n"
             f"If yes, run **/join** and select **{mentioned_activity}**.\n"
             f"Then use **/queue** (or check {queue_channel}) to confirm your spot."
-        )
+        ), mentioned_activity
 
     if asks_signup and mentioned_activity and _is_raid_or_dungeon(mentioned_activity):
         alias_hint = " (recognized from abbreviation)" if matched_by_alias else ""
         return with_footer(
             f"Do you want to be signed up for **{mentioned_activity}**{alias_hint} queue?\n"
             f"Use **/join** and pick **{mentioned_activity}**, then check **/queue**."
-        )
+        ), mentioned_activity
 
     if asks_signup and raid_or_dungeon:
         return with_footer(
@@ -617,16 +782,16 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             f"2) Check your spot with **/queue** (or watch {queue_channel}).\n"
             f"3) Watch {signup_channel} for event posts and react **✅** to join or **🔁** for backup.\n"
             "Need to back out? Use **/leave**."
-        )
+        ), None
 
     if asks_queue_spot and activity_context:
-        return with_footer(f"Use **/queue** to see your current position. Queue boards are posted in {queue_channel}.")
+        return with_footer(f"Use **/queue** to see your current position. Queue boards are posted in {queue_channel}."), None
 
     if asks_where and any(k in text for k in ("sign", "join", "event", "raid", "dungeon")):
         return with_footer(
             f"Raid and dungeon events are posted in {signup_channel}, and chat/LFG updates happen in {lfg_channel}. "
             "Use **/join** to enter the queue, then **/queue** to see your position."
-        )
+        ), None
 
     if asks_reactions and activity_context:
         return with_footer(
@@ -635,16 +800,16 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "• **🔁** = backup/waitlist\n"
             "• **📝** = interest note (when enabled)\n"
             "• **❌** = leave/cancel your participation"
-        )
+        ), None
 
     if asks_leave and any(k in text for k in ("raid", "dungeon", "queue", "run", "signup")):
-        return with_footer("Use **/leave** to step out of a raid/dungeon queue or signup.")
+        return with_footer("Use **/leave** to step out of a raid/dungeon queue or signup."), None
 
     if asks_sherpa and activity_context:
         return with_footer(
             "New/learning runs are welcome. Join with **/join**, then watch event posts in "
             f"{signup_channel}. If Sherpas are needed, those runs will call it out in {lfg_channel}."
-        )
+        ), None
 
     if asks_hosting and activity_context:
         return with_footer(
@@ -652,13 +817,13 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "• **/event** for normal player signups\n"
             "• **/event_sherpa** for Sherpa-only signups\n"
             "If permissions block it, ask a founder/admin for event-host access."
-        )
+        ), None
 
     if asks_time and activity_context:
         return with_footer(
             f"Event posts in {signup_channel} include the scheduled time. "
             "You’ll also get reminders before start when applicable."
-        )
+        ), None
 
     if has_question_tone and (activity_context or direct_bot_question):
         return with_footer(
@@ -670,9 +835,9 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "• **What do the reactions mean?**\n"
             "• **How do I leave the queue?**\n"
             "• **Which command should I use?**"
-        )
+        ), None
 
-    return None
+    return None, None
 
 def _find_activity_image(activity: str) -> Optional[str]:
     aset = os.path.join(os.path.dirname(__file__), "assets")
@@ -1825,6 +1990,20 @@ async def on_message(message: discord.Message):
         if int(channel_id) not in _help_channel_ids():
             return
 
+        pending_activity = _get_help_queue_confirm(int(channel_id), int(message.author.id))
+        if pending_activity:
+            if _is_affirmative_help_reply(message.content or ""):
+                _clear_help_queue_confirm(int(channel_id), int(message.author.id))
+                await _join_queue_from_help_confirmation(message, pending_activity)
+                return
+            if _is_negative_help_reply(message.content or ""):
+                _clear_help_queue_confirm(int(channel_id), int(message.author.id))
+                await message.reply(
+                    f"No problem. If you change your mind, use **/join** for **{pending_activity}**.\n\n{HELP_REMINDER_FOOTER}",
+                    mention_author=False,
+                )
+                return
+
         is_direct_bot_question = False
         try:
             if bot.user:
@@ -1832,11 +2011,13 @@ async def on_message(message: discord.Message):
         except Exception:
             is_direct_bot_question = False
 
-        reply = _chat_help_reply(message.content or "", direct_bot_question=is_direct_bot_question)
+        reply, pending_prompt_activity = _chat_help_reply(message.content or "", direct_bot_question=is_direct_bot_question)
         if reply:
             if _help_reply_rate_limited(int(channel_id), int(message.author.id)):
                 return
             await message.reply(reply, mention_author=False)
+            if pending_prompt_activity:
+                _set_help_queue_confirm(int(channel_id), int(message.author.id), pending_prompt_activity)
     except Exception as e:
         try: print("chat help reply failed:", e)
         except Exception: pass

--- a/main.py
+++ b/main.py
@@ -145,6 +145,7 @@ COOLDOWNS: Dict[str, Dict[int, int]] = {}
 # (channel_id, user_id) -> last auto-help reply epoch seconds
 HELP_REPLY_LAST_SENT: Dict[Tuple[int, int], int] = {}
 HELP_REPLY_COOLDOWN_SECONDS = 20
+_ACTIVITY_ALIAS_CACHE: Optional[Dict[str, str]] = None
 
 # ---------------------------
 # External Helpers (project)
@@ -461,6 +462,84 @@ def _help_reply_rate_limited(channel_id: int, user_id: int) -> bool:
     except Exception:
         return False
 
+def _find_activity_by_terms(*terms: str) -> Optional[str]:
+    norm_terms = [_normalize_activity_text(t) for t in terms if t]
+    if not norm_terms:
+        return None
+    for act in ALL_ACTIVITIES:
+        norm_act = _normalize_activity_text(act)
+        if norm_act and all(t in norm_act for t in norm_terms):
+            return act
+    return None
+
+def _activity_alias_map() -> Dict[str, str]:
+    global _ACTIVITY_ALIAS_CACHE
+    if _ACTIVITY_ALIAS_CACHE is not None:
+        return _ACTIVITY_ALIAS_CACHE
+
+    aliases: Dict[str, str] = {}
+
+    # Auto-generate simple initialisms (e.g., "last wish" -> "lw").
+    stop_words = {"of", "the", "and", "a", "an", "to", "for", "in", "on"}
+    for act in ALL_ACTIVITIES:
+        words = [w for w in _normalize_activity_text(act).split() if w and w not in stop_words]
+        if len(words) >= 2:
+            init = "".join(w[0] for w in words)
+            if 2 <= len(init) <= 5:
+                aliases.setdefault(init, act)
+
+    # Common Destiny abbreviations (raids + dungeons).
+    manual_alias_terms: List[Tuple[str, Tuple[str, ...]]] = [
+        ("vog", ("vault", "glass")),
+        ("lw", ("last", "wish")),
+        ("gos", ("garden", "salvation")),
+        ("dsc", ("deep", "stone", "crypt")),
+        ("votd", ("vow", "disciple")),
+        ("vow", ("vow", "disciple")),
+        ("kf", ("king", "fall")),
+        ("ron", ("root", "nightmare")),
+        ("ce", ("crota", "end")),
+        ("se", ("salvation", "edge")),
+        ("sos", ("spire", "stars")),
+        ("eow", ("eater", "world")),
+        ("poh", ("pit", "heresy")),
+        ("st", ("shattered", "throne")),
+        ("goa", ("grasp", "avarice")),
+        ("sotw", ("spire", "watcher")),
+        ("gotd", ("ghost", "deep")),
+        ("wr", ("warlord", "ruin")),
+        ("vh", ("vesper", "host")),
+        ("sd", ("sunder", "doctrine")),
+    ]
+    for alias, terms in manual_alias_terms:
+        act = _find_activity_by_terms(*terms)
+        if act:
+            aliases[alias] = act
+
+    _ACTIVITY_ALIAS_CACHE = aliases
+    return aliases
+
+def _extract_activity_from_help_text(message_text: str) -> Tuple[Optional[str], bool]:
+    """Return (activity_name, matched_by_alias)."""
+    norm_text = _normalize_activity_text(message_text or "")
+    if not norm_text:
+        return None, False
+
+    # Full-name mention first (prefer longest activity name).
+    sorted_activities = sorted(ALL_ACTIVITIES, key=lambda a: len(_normalize_activity_text(a)), reverse=True)
+    for act in sorted_activities:
+        norm_act = _normalize_activity_text(act)
+        if not norm_act:
+            continue
+        if re.search(rf"\b{re.escape(norm_act)}\b", norm_text):
+            return act, False
+
+    # Abbreviation mention second.
+    for alias, act in _activity_alias_map().items():
+        if re.search(rf"\b{re.escape(alias)}\b", norm_text):
+            return act, True
+    return None, False
+
 def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) -> Optional[str]:
     text = " ".join((message_text or "").lower().split())
     if not text:
@@ -477,6 +556,7 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
     )
     asks_signup = has_any("sign up", "signup", "join", "register", "queue", "lfg")
     asks_join_raid = has_any("how do i join a raid", "join raid", "join a raid")
+    asks_how_to_join = has_any("how do i join", "how to join", "how can i join", "where do i join")
     asks_where = has_any("where", "which channel", "what channel")
     asks_leave = has_any("leave", "cancel", "drop", "remove me", "step out")
     asks_commands = has_any("commands", "command", "slash", "bot command", "how to use bot")
@@ -494,6 +574,7 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
     signup_channel = _channel_mention_or_fallback(EVENT_SIGNUP_CHANNEL_ID, "the event-signup channel")
     queue_channel = _channel_mention_or_fallback(RAID_QUEUE_CHANNEL_ID, "the queue channel")
     lfg_channel = _channel_mention_or_fallback(LFG_CHAT_CHANNEL_ID, "#lfg")
+    mentioned_activity, matched_by_alias = _extract_activity_from_help_text(text)
 
     if asks_commands and activity_context:
         return with_footer(
@@ -512,6 +593,21 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "1) Use **/join** and select the raid.\n"
             f"2) Use **/queue** to check your place (or watch {queue_channel}).\n"
             f"3) Watch {signup_channel} and react **✅** when your run is posted."
+        )
+
+    if asks_how_to_join and mentioned_activity and _is_raid_or_dungeon(mentioned_activity):
+        alias_hint = " (recognized from abbreviation)" if matched_by_alias else ""
+        return with_footer(
+            f"I see **{mentioned_activity}**{alias_hint}. Do you want to be signed up for that queue?\n"
+            f"If yes, run **/join** and select **{mentioned_activity}**.\n"
+            f"Then use **/queue** (or check {queue_channel}) to confirm your spot."
+        )
+
+    if asks_signup and mentioned_activity and _is_raid_or_dungeon(mentioned_activity):
+        alias_hint = " (recognized from abbreviation)" if matched_by_alias else ""
+        return with_footer(
+            f"Do you want to be signed up for **{mentioned_activity}**{alias_hint} queue?\n"
+            f"Use **/join** and pick **{mentioned_activity}**, then check **/queue**."
         )
 
     if asks_signup and raid_or_dungeon:

--- a/main.py
+++ b/main.py
@@ -142,6 +142,9 @@ CHECKED: Dict[str, Set[int]] = {}
 CATTY_RUNS: Dict[str, Set[int]] = {}
 # activity -> { user_id -> cooldown_until_epoch }
 COOLDOWNS: Dict[str, Dict[int, int]] = {}
+# (channel_id, user_id) -> last auto-help reply epoch seconds
+HELP_REPLY_LAST_SENT: Dict[Tuple[int, int], int] = {}
+HELP_REPLY_COOLDOWN_SECONDS = 20
 
 # ---------------------------
 # External Helpers (project)
@@ -439,20 +442,65 @@ def _channel_mention_or_fallback(channel_id: Optional[int], fallback: str) -> st
         pass
     return fallback
 
-def _chat_help_reply(message_text: str) -> Optional[str]:
+def _help_reply_rate_limited(channel_id: int, user_id: int) -> bool:
+    """Return True if we should skip replying due to short cooldown."""
+    try:
+        now = int(datetime.utcnow().timestamp())
+        key = (int(channel_id), int(user_id))
+        last = int(HELP_REPLY_LAST_SENT.get(key, 0) or 0)
+        if (now - last) < int(HELP_REPLY_COOLDOWN_SECONDS):
+            return True
+        HELP_REPLY_LAST_SENT[key] = now
+        # Keep this small and bounded over long uptimes.
+        if len(HELP_REPLY_LAST_SENT) > 5000:
+            cutoff = now - 6 * 60 * 60
+            for k, ts in list(HELP_REPLY_LAST_SENT.items()):
+                if int(ts) < cutoff:
+                    HELP_REPLY_LAST_SENT.pop(k, None)
+        return False
+    except Exception:
+        return False
+
+def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) -> Optional[str]:
     text = " ".join((message_text or "").lower().split())
     if not text:
         return None
 
-    has_question_tone = ("?" in text) or text.startswith(("how ", "where ", "what ", "can ", "do ", "is ", "are "))
-    asks_signup = any(k in text for k in ("sign up", "signup", "join", "register", "queue", "lfg"))
-    raid_or_dungeon = any(k in text for k in ("raid", "raids", "dungeon", "dungeons"))
-    asks_where = any(k in text for k in ("where", "which channel", "what channel"))
-    asks_leave = any(k in text for k in ("leave", "cancel", "drop", "remove me"))
+    def has_any(*phrases: str) -> bool:
+        return any(p in text for p in phrases)
+
+    has_question_tone = ("?" in text) or text.startswith(
+        ("how ", "where ", "what ", "can ", "do ", "is ", "are ", "when ", "which ", "who ", "why ", "help")
+    )
+    asks_signup = has_any("sign up", "signup", "join", "register", "queue", "lfg")
+    asks_where = has_any("where", "which channel", "what channel")
+    asks_leave = has_any("leave", "cancel", "drop", "remove me", "step out")
+    asks_commands = has_any("commands", "command", "slash", "bot command", "how to use bot")
+    asks_reactions = has_any("reaction", "reactions", "emoji", "what does ✅", "what does 🔁", "what does 📝", "what does ❌", "backup")
+    asks_queue_spot = has_any("queue position", "spot in queue", "where am i in queue", "am i queued", "queue spot")
+    asks_sherpa = has_any("sherpa", "teach", "teaching run", "first time", "new player")
+    asks_hosting = has_any("create event", "make event", "host run", "post event", "schedule run")
+    asks_time = has_any("when", "what time", "start time", "timezone", "utc", "est", "pst", "cst", "mst")
+    raid_or_dungeon = has_any("raid", "raids", "dungeon", "dungeons")
+    activity_context = has_any(
+        "raid", "raids", "dungeon", "dungeons", "lfg", "queue", "join", "signup", "sign up",
+        "event", "events", "run", "runs", "sherpa", "fireteam", "activity"
+    )
 
     signup_channel = _channel_mention_or_fallback(EVENT_SIGNUP_CHANNEL_ID, "the event-signup channel")
     queue_channel = _channel_mention_or_fallback(RAID_QUEUE_CHANNEL_ID, "the queue channel")
     lfg_channel = _channel_mention_or_fallback(LFG_CHAT_CHANNEL_ID, "#lfg")
+
+    if asks_commands and activity_context:
+        return (
+            "Common commands:\n"
+            "• **/join** — join an activity queue\n"
+            "• **/queue** — view current queues\n"
+            "• **/leave** — leave a queue/signup\n"
+            "• **/event** — create a player event signup\n"
+            "• **/event_sherpa** — create a Sherpa-only signup\n"
+            "If you’re unsure, ask your question and I’ll point you to the right command."
+        )
 
     if asks_signup and raid_or_dungeon:
         return (
@@ -463,21 +511,56 @@ def _chat_help_reply(message_text: str) -> Optional[str]:
             "Need to back out? Use **/leave**."
         )
 
+    if asks_queue_spot and activity_context:
+        return f"Use **/queue** to see your current position. Queue boards are posted in {queue_channel}."
+
     if asks_where and any(k in text for k in ("sign", "join", "event", "raid", "dungeon")):
         return (
             f"Raid and dungeon events are posted in {signup_channel}, and chat/LFG updates happen in {lfg_channel}. "
             "Use **/join** to enter the queue, then **/queue** to see your position."
         )
 
+    if asks_reactions and activity_context:
+        return (
+            "Reaction guide on event posts:\n"
+            "• **✅** = join if a slot is open\n"
+            "• **🔁** = backup/waitlist\n"
+            "• **📝** = interest note (when enabled)\n"
+            "• **❌** = leave/cancel your participation"
+        )
+
     if asks_leave and any(k in text for k in ("raid", "dungeon", "queue", "run", "signup")):
         return "Use **/leave** to step out of a raid/dungeon queue or signup."
 
-    if has_question_tone and any(k in text for k in ("raid", "dungeon", "lfg", "queue", "signup", "join", "event")):
+    if asks_sherpa and activity_context:
         return (
-            "I can help with raid/dungeon signups. Try:\n"
+            "New/learning runs are welcome. Join with **/join**, then watch event posts in "
+            f"{signup_channel}. If Sherpas are needed, those runs will call it out in {lfg_channel}."
+        )
+
+    if asks_hosting and activity_context:
+        return (
+            "To host, use:\n"
+            "• **/event** for normal player signups\n"
+            "• **/event_sherpa** for Sherpa-only signups\n"
+            "If permissions block it, ask a founder/admin for event-host access."
+        )
+
+    if asks_time and activity_context:
+        return (
+            f"Event posts in {signup_channel} include the scheduled time. "
+            "You’ll also get reminders before start when applicable."
+        )
+
+    if has_question_tone and (activity_context or direct_bot_question):
+        return (
+            "I can help with raid/dungeon/LFG questions. Try asking:\n"
             "• **How do I sign up for raids?**\n"
             "• **Where are event posts?**\n"
-            "• **How do I leave the queue?**"
+            "• **How do I check queue position?**\n"
+            "• **What do the reactions mean?**\n"
+            "• **How do I leave the queue?**\n"
+            "• **Which command should I use?**"
         )
 
     return None
@@ -1633,8 +1716,17 @@ async def on_message(message: discord.Message):
         if int(channel_id) not in _help_channel_ids():
             return
 
-        reply = _chat_help_reply(message.content or "")
+        is_direct_bot_question = False
+        try:
+            if bot.user:
+                is_direct_bot_question = bot.user.mentioned_in(message)
+        except Exception:
+            is_direct_bot_question = False
+
+        reply = _chat_help_reply(message.content or "", direct_bot_question=is_direct_bot_question)
         if reply:
+            if _help_reply_rate_limited(int(channel_id), int(message.author.id)):
+                return
             await message.reply(reply, mention_author=False)
     except Exception as e:
         try: print("chat help reply failed:", e)

--- a/main.py
+++ b/main.py
@@ -421,6 +421,67 @@ def _resolve_welcome_channel_id(guild: Optional[discord.Guild]) -> Optional[int]
         except Exception: pass
     return None
 
+def _help_channel_ids() -> Set[int]:
+    ids: Set[int] = set()
+    for cid in (GENERAL_CHANNEL_ID, LFG_CHAT_CHANNEL_ID):
+        try:
+            if cid:
+                ids.add(int(cid))
+        except Exception:
+            pass
+    return ids
+
+def _channel_mention_or_fallback(channel_id: Optional[int], fallback: str) -> str:
+    try:
+        if channel_id:
+            return f"<#{int(channel_id)}>"
+    except Exception:
+        pass
+    return fallback
+
+def _chat_help_reply(message_text: str) -> Optional[str]:
+    text = " ".join((message_text or "").lower().split())
+    if not text:
+        return None
+
+    has_question_tone = ("?" in text) or text.startswith(("how ", "where ", "what ", "can ", "do ", "is ", "are "))
+    asks_signup = any(k in text for k in ("sign up", "signup", "join", "register", "queue", "lfg"))
+    raid_or_dungeon = any(k in text for k in ("raid", "raids", "dungeon", "dungeons"))
+    asks_where = any(k in text for k in ("where", "which channel", "what channel"))
+    asks_leave = any(k in text for k in ("leave", "cancel", "drop", "remove me"))
+
+    signup_channel = _channel_mention_or_fallback(EVENT_SIGNUP_CHANNEL_ID, "the event-signup channel")
+    queue_channel = _channel_mention_or_fallback(RAID_QUEUE_CHANNEL_ID, "the queue channel")
+    lfg_channel = _channel_mention_or_fallback(LFG_CHAT_CHANNEL_ID, "#lfg")
+
+    if asks_signup and raid_or_dungeon:
+        return (
+            "For raid/dungeon signups:\n"
+            "1) Use **/join** and pick the activity.\n"
+            f"2) Check your spot with **/queue** (or watch {queue_channel}).\n"
+            f"3) Watch {signup_channel} for event posts and react **✅** to join or **🔁** for backup.\n"
+            "Need to back out? Use **/leave**."
+        )
+
+    if asks_where and any(k in text for k in ("sign", "join", "event", "raid", "dungeon")):
+        return (
+            f"Raid and dungeon events are posted in {signup_channel}, and chat/LFG updates happen in {lfg_channel}. "
+            "Use **/join** to enter the queue, then **/queue** to see your position."
+        )
+
+    if asks_leave and any(k in text for k in ("raid", "dungeon", "queue", "run", "signup")):
+        return "Use **/leave** to step out of a raid/dungeon queue or signup."
+
+    if has_question_tone and any(k in text for k in ("raid", "dungeon", "lfg", "queue", "signup", "join", "event")):
+        return (
+            "I can help with raid/dungeon signups. Try:\n"
+            "• **How do I sign up for raids?**\n"
+            "• **Where are event posts?**\n"
+            "• **How do I leave the queue?**"
+        )
+
+    return None
+
 def _find_activity_image(activity: str) -> Optional[str]:
     aset = os.path.join(os.path.dirname(__file__), "assets")
     if not os.path.isdir(aset):
@@ -1560,6 +1621,27 @@ async def on_member_join(member: discord.Member):
             except Exception: pass
     except Exception:
         pass
+
+@bot.event
+async def on_message(message: discord.Message):
+    try:
+        if message.author.bot:
+            return
+        channel_id = getattr(message.channel, "id", None)
+        if not channel_id:
+            return
+        if int(channel_id) not in _help_channel_ids():
+            return
+
+        reply = _chat_help_reply(message.content or "")
+        if reply:
+            await message.reply(reply, mention_author=False)
+    except Exception as e:
+        try: print("chat help reply failed:", e)
+        except Exception: pass
+    finally:
+        # Keep prefix-command behavior intact when on_message is present.
+        await bot.process_commands(message)
 
 # ---------------------------
 # Queue Boards (optional utility)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- broaden auto-help coverage in `GENERAL_CHANNEL_ID` and `LFG_CHAT_CHANNEL_ID` for raid/dungeon/LFG questions
- add explicit handling for "how do I join a raid"
- detect activity mentions from full names and common abbreviations (e.g., VOG, KF, RON, GOTD, SOTW, etc.)
- when users ask how to join and include a specific raid/dungeon (or abbreviation), ask if they want to be signed up for that activity queue
- add yes/no follow-up handling for those prompts:
  - if user replies **yes** within a short window, auto-add them to that queue
  - if user replies **no**, clear the pending prompt and send a friendly fallback
- enforce queue safeguards on yes-confirmation joins (sherpa restriction, cooldowns, max-2-queues limit, already-queued handling)
- send a **Queue Confirmation embed** after yes processing with status/details
- append a consistent reminder to every help response and confirmation footer: `Don't forget to message @GFerryGoon.`
- keep anti-spam behavior with per-user reply cooldown
- preserve command handling via `bot.process_commands(message)`

## Validation
- `python3 -m py_compile main.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6c7ebda-376e-4f72-b842-63f6ad61ef9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6c7ebda-376e-4f72-b842-63f6ad61ef9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

