### PR TITLE
Reduce unnecessary help-menu replies for normal LFG chatter

### DIFF
--- a/main.py
+++ b/main.py
@@ -737,10 +737,14 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
     asks_sherpa = has_any("sherpa", "teach", "teaching run", "first time", "new player")
     asks_hosting = has_any("create event", "make event", "host run", "post event", "schedule run")
     asks_time = has_any("when", "what time", "start time", "timezone", "utc", "est", "pst", "cst", "mst")
+    asks_help_style = has_any(
+        "help", "how do i", "how to", "how can i", "where do i", "where are",
+        "what does", "which command", "what command", "can you help",
+    )
     raid_or_dungeon = has_any("raid", "raids", "dungeon", "dungeons")
     activity_context = has_any(
         "raid", "raids", "dungeon", "dungeons", "lfg", "queue", "join", "signup", "sign up",
-        "event", "events", "run", "runs", "sherpa", "fireteam", "activity"
+        "event", "events", "sherpa"
     )
 
     signup_channel = _channel_mention_or_fallback(EVENT_SIGNUP_CHANNEL_ID, "the event-signup channel")
@@ -835,7 +839,7 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "You’ll also get reminders before start when applicable."
         ), None
 
-    if has_question_tone and (activity_context or direct_bot_question):
+    if has_question_tone and (direct_bot_question or (asks_help_style and activity_context)):
         return with_footer(
             "I can help with raid/dungeon/LFG questions. Try asking:\n"
             "• **How do I join a raid?**\n"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- tune chat auto-help fallback so it only triggers for explicit help-style questions (or direct bot mentions)
- reduce false positives from ordinary LFG chatter like "anyone wanna run ...?"
- narrow generic `activity_context` terms to avoid overmatching normal conversation

## Validation
- `python3 -m py_compile main.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6c7ebda-376e-4f72-b842-63f6ad61ef9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6c7ebda-376e-4f72-b842-63f6ad61ef9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

