### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+GoonBot is a Destiny 2 Discord bot built with Python and `discord.py`. The application lives primarily in `main.py` (~5600 lines) with helpers `env_safety.py` and `presets_loader.py`. There is no database — persistent state is stored as JSON files under `./data/` (auto-created at startup).
+
+### Running the bot
+
+- **Start command:** `python main.py` (see also `Procfile` and `render.yaml`)
+- **Required secret:** `DISCORD_TOKEN` — the process exits immediately if unset or invalid (`env_safety.py`)
+- Channel and role IDs come from environment variables, with fallbacks in `channel_ids.json`
+- Full E2E testing requires a Discord test server with matching channel/role IDs and the bot invited with **Message Content** and **Server Members** intents enabled
+
+### Dependencies
+
+- Install: `pip install -r requirements.txt` (single dependency: `discord.py`)
+- Python 3.9+ (uses stdlib `zoneinfo`; VM ships with 3.12)
+
+### Linting and verification
+
+- No linter or test suite is configured in the repo
+- Basic checks: `python3 -m py_compile main.py env_safety.py presets_loader.py`
+- Optional: `python3 -m pyflakes main.py` (4 pre-existing warnings in `main.py`)
+- Smoke test without Discord: import `presets_loader.load_presets()` and `import main` (module load only; do not call `bot.run()` without a token)
+
+### Key gotchas
+
+- `main.py` is very large; use search or partial reads instead of loading the whole file
+- The `data/` directory and JSON state files are created lazily on first write
+- The bot uses slash commands (`app_commands`), not prefix commands
+- Verify live connectivity with `/ping` in Discord once `DISCORD_TOKEN` is set
+- There is no Docker, web server, or local HTTP port — the bot is a long-running worker process connecting outbound to Discord


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents development environment setup for Cursor Cloud agents working on GoonBot.

- Adds `AGENTS.md` with run commands, dependency notes, lint/verification steps, and Discord-specific gotchas
- VM update script: `pip install -r requirements.txt`

## Environment verification (this session)

- Python 3.12.3 with `discord.py` 2.7.1 installed
- `py_compile` passes on all Python modules
- Presets, `destiny_data.json`, and `channel_ids.json` load successfully
- `main` module imports cleanly; `/ping` slash command is registered
- Bot startup reaches Discord login when `DISCORD_TOKEN` is set (401 without a valid token)

Full E2E testing (`/ping` in Discord) requires a valid `DISCORD_TOKEN` secret.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3186365c-ae7b-45b5-8e84-393166496237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3186365c-ae7b-45b5-8e84-393166496237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

