### PR TITLE
Add Pantheon:Calus to raid activity options

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -1,6 +1,7 @@
 {
   "raids": [
     "\ud83c\udfdc\ufe0f Desert Perpetual \ud83c\udfdc\ufe0f",
+    "\ud83c\udfdb\ufe0f Pantheon:Calus \ud83d\udc51",
     "\ud83d\udc0d Last Wish \ud83d\udc0d",
     "\ud83c\udf31 Garden of Salvation \ud83c\udf31",
     "\u2744\ufe0f Deep Stone Crypt \u2744\ufe0f",
@@ -9,8 +10,7 @@
     "\ud83d\udc51 King's Fall \ud83d\udc51",
     "\ud83c\udf19 Root of Nightmares \ud83c\udf19",
     "\u2694\ufe0f Crota's End \u2694\ufe0f",
-    "\ud83d\ude4f Salvation's Edge \ud83d\ude4f",
-    "\ud83c\udfdb\ufe0f Pantheon:Calus \ud83d\udc51"
+    "\ud83d\ude4f Salvation's Edge \ud83d\ude4f"
   ],
   "dungeons": [
     "\ud83d\udc51 The Shattered Throne \ud83d\udc51",

--- a/activities.json
+++ b/activities.json
@@ -9,7 +9,8 @@
     "\ud83d\udc51 King's Fall \ud83d\udc51",
     "\ud83c\udf19 Root of Nightmares \ud83c\udf19",
     "\u2694\ufe0f Crota's End \u2694\ufe0f",
-    "\ud83d\ude4f Salvation's Edge \ud83d\ude4f"
+    "\ud83d\ude4f Salvation's Edge \ud83d\ude4f",
+    "\ud83c\udfdb\ufe0f Pantheon:Calus \ud83d\udc51"
   ],
   "dungeons": [
     "\ud83d\udc51 The Shattered Throne \ud83d\udc51",

--- a/destiny_data.json
+++ b/destiny_data.json
@@ -230,6 +230,7 @@
     "Gambit",
     "Solo Content",
     "Salvation's Edge",
+    "Pantheon:Calus",
     "Crota's End",
     "Root of Nightmares",
     "King's Fall",

--- a/main.py
+++ b/main.py
@@ -243,7 +243,7 @@ def _cap_for_activity(activity: str) -> int:
 
     # Heuristic fallback by keywords (kept broad, errs toward raid=6)
     a = act.lower()
-    if any(k in a for k in ("raid", "vault", "wish", "garden", "crota", "salvation", "vow", "king", "root", "nightmare", "edge", "desert")):
+    if any(k in a for k in ("raid", "vault", "wish", "garden", "crota", "salvation", "vow", "king", "root", "nightmare", "edge", "desert", "pantheon", "calus")):
         return 6
     if any(k in a for k in ("dungeon", "pit", "spire", "deep", "watcher", "throne", "prophecy", "grasp", "duality", "ghost", "warlord", "ruin", "sunder", "doctrine", "vesper", "host", "avarice")):
         return 3
@@ -341,7 +341,7 @@ def _is_raid_or_dungeon(activity: str) -> bool:
     except Exception:
         pass
     a = act.lower()
-    return any(k in a for k in ("raid", "vault", "wish", "garden", "crota", "salvation", "vow", "king", "root", "nightmare")) or any(
+    return any(k in a for k in ("raid", "vault", "wish", "garden", "crota", "salvation", "vow", "king", "root", "nightmare", "pantheon", "calus")) or any(
         k in a for k in ("dungeon", "pit", "spire", "deep", "watcher", "throne", "prophecy", "grasp", "duality", "ghost", "warlord", "ruin", "avarice")
     )
 
@@ -503,6 +503,8 @@ def _activity_alias_map() -> Dict[str, str]:
         ("ron", ("root", "nightmare")),
         ("ce", ("crota", "end")),
         ("se", ("salvation", "edge")),
+        ("calus", ("pantheon", "calus")),
+        ("pantheon", ("pantheon", "calus")),
         ("sos", ("spire", "stars")),
         ("eow", ("eater", "world")),
         ("poh", ("pit", "heresy")),

--- a/main.py
+++ b/main.py
@@ -303,13 +303,38 @@ def sherpa_host_only():
     return app_commands.check(predicate)
 
 async def _activity_autocomplete(interaction: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
-    cur = (current or "").lower()
-    out: List[app_commands.Choice[str]] = []
+    cur_raw = (current or "").strip()
+    cur = cur_raw.lower()
+    cur_norm = _normalize_activity_text(cur_raw)
+
+    def _match_score(act: str) -> int:
+        if not cur:
+            return 0
+        act_low = act.lower()
+        act_norm = _normalize_activity_text(act)
+        if act_low.startswith(cur) or act_norm.startswith(cur_norm):
+            return 3
+        if cur in act_low or (cur_norm and cur_norm in act_norm):
+            return 2
+        for alias, target in _activity_alias_map().items():
+            if target == act and (cur == alias or cur_norm == _normalize_activity_text(alias)):
+                return 4
+        return 0
+
+    ranked: List[Tuple[int, str]] = []
     for act in ALL_ACTIVITIES:
-        if not cur or cur in act.lower():
-            out.append(app_commands.Choice(name=act, value=act))
-            if len(out) >= 25:
-                break
+        score = _match_score(act)
+        if not cur or score > 0:
+            ranked.append((score, act))
+
+    if cur:
+        ranked.sort(key=lambda item: (-item[0], item[1].lower()))
+    else:
+        ranked.sort(key=lambda item: item[1].lower())
+
+    out: List[app_commands.Choice[str]] = []
+    for _, act in ranked[:25]:
+        out.append(app_commands.Choice(name=act, value=act))
     return out
 
 def _activity_color(activity: str) -> int:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Pantheon:Calus** as a selectable raid across queue/schedule commands and Build of the Week.

## Changes

- **`activities.json`** — added `🏛️ Pantheon:Calus 👑` near the top of the `raids` list
- **`destiny_data.json`** — added `Pantheon:Calus` for `/build` autocomplete
- **`main.py`** — added `calus` / `pantheon` aliases, raid heuristics, and improved `_activity_autocomplete` so `/join` finds activities by normalized name and alias (not just raw emoji strings)

## Deploy note

After merging, **restart the bot** on Render (or wherever it runs) so it reloads `activities.json`. Slash command definitions sync on startup.

## Verification

- Autocomplete returns Pantheon for queries: `pantheon`, `calus`, `Pantheon:Calus`
- `_resolve_activity("calus")` resolves correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3186365c-ae7b-45b5-8e84-393166496237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3186365c-ae7b-45b5-8e84-393166496237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

