### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+GoonBot is a single-process **discord.py worker bot** (not an HTTP web service, despite the
+`Procfile` saying `web:`). It connects to the Discord gateway and manages raid/dungeon
+sign-up queues, sherpa signups, scheduling, reminders, and "Build of the Week" posts.
+
+### Services / how to run
+
+- Dependencies are installed into a virtualenv at `.venv` (the update script creates it and
+  installs `requirements.txt`, whose only dependency is `discord.py`).
+- Run the bot: `.venv/bin/python main.py` (entry point is `main.py`, boot is under
+  `if __name__ == "__main__"`). There is no port to bind; it's a gateway worker.
+- Required secret: `DISCORD_TOKEN`. `env_safety.get_token()` rejects a missing token **and**
+  any token without a `.` in it, so a placeholder must look like `abc.def.ghi` to get past the
+  sanity check (it will then fail at Discord login). A real bot token tied to the target guild
+  is required for an actual end-to-end run.
+- Optional config: channel IDs are read from env vars first, then fall back to
+  `channel_ids.json`; activity presets come from `activities.json` (validated by
+  `presets_loader.load_presets`). `FOUNDER_USER_ID` / `SHERPA_ASSISTANT_ROLE_ID` are also env-driven.
+- Runtime state is persisted to `$GOONBOT_DATA_DIR` / `$BOT_DATA_DIR`, defaulting to `./data`
+  (created automatically on startup).
+
+### Lint / test / build
+
+- No test suite and no linter are configured. Use `.venv/bin/python -m py_compile main.py
+  presets_loader.py env_safety.py` as a syntax/compile check, and
+  `.venv/bin/python -c "import main"` as an import smoke test (it builds the bot and registers
+  ~21 slash commands without connecting).
+
+### Notes / gotchas
+
+- The bot needs the **Members** and **Message Content** privileged intents enabled in the
+  Discord developer portal for the matching application/token.
+- The committed `core` file is a stray ELF core dump and is unrelated to the bot.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for GoonBot (a `discord.py` worker bot) and documents it for future Cloud Agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run the bot, the required `DISCORD_TOKEN` secret, config sources, and the lack of a test suite/linter.
- Registers a minimal, idempotent update script that creates a `.venv` and installs `requirements.txt` (`discord.py`).

No application code was modified.

## Verification

- `py_compile` of `main.py`, `presets_loader.py`, `env_safety.py` — OK.
- `import main` smoke test — builds the bot and registers 21 slash commands; presets load.
- `python main.py` with a placeholder token reaches Discord's login endpoint and fails only with `LoginFailure: Improper token has been passed.`, confirming deps + network are working.

A real end-to-end run (bot connecting to a guild) requires a valid `DISCORD_TOKEN` provided via secrets.

[env_verification.log](https://cursor.com/agents/bc-87bb2697-f48e-4170-ae3f-2e32e3095d15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_verification.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87bb2697-f48e-4170-ae3f-2e32e3095d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87bb2697-f48e-4170-ae3f-2e32e3095d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

