### PR TITLE
Add ordered queue pull list command

### DIFF
--- a/main.py
+++ b/main.py
@@ -2450,6 +2450,7 @@ async def on_message(message: discord.Message):
         if not channel_id:
             return
         if int(channel_id) not in _help_channel_ids():
+            await _bump_active_lists_for_channel(int(channel_id))
             return
 
         pending_activity = _get_help_queue_confirm(int(channel_id), int(message.author.id))
@@ -2457,6 +2458,7 @@ async def on_message(message: discord.Message):
             if _is_affirmative_help_reply(message.content or ""):
                 _clear_help_queue_confirm(int(channel_id), int(message.author.id))
                 await _join_queue_from_help_confirmation(message, pending_activity)
+                await _bump_active_lists_for_channel(int(channel_id))
                 return
             if _is_negative_help_reply(message.content or ""):
                 _clear_help_queue_confirm(int(channel_id), int(message.author.id))
@@ -2464,6 +2466,7 @@ async def on_message(message: discord.Message):
                     f"No problem. If you change your mind, use **/join** for **{pending_activity}**.\n\n{HELP_REMINDER_FOOTER}",
                     mention_author=False,
                 )
+                await _bump_active_lists_for_channel(int(channel_id))
                 return
 
         is_direct_bot_question = False
@@ -2480,6 +2483,7 @@ async def on_message(message: discord.Message):
             await message.reply(reply, mention_author=False)
             if pending_prompt_activity:
                 _set_help_queue_confirm(int(channel_id), int(message.author.id), pending_prompt_activity)
+        await _bump_active_lists_for_channel(int(channel_id))
     except Exception as e:
         try: print("chat help reply failed:", e)
         except Exception: pass
@@ -2684,17 +2688,47 @@ async def _update_list_message(list_id: int) -> None:
         if not ch_id:
             return
         ch = bot.get_channel(ch_id) or await bot.fetch_channel(ch_id)
-        msg = await ch.fetch_message(int(list_id))
         guild_id = data.get("guild_id")
         guild = bot.get_guild(int(guild_id)) if guild_id else None
+        active_id = int(data.get("message_id") or list_id)
         embed = await _render_list_embed(guild, data)
         if data.get("closed"):
+            msg = await ch.fetch_message(active_id)
             await msg.edit(embed=embed, view=None)
         else:
-            await msg.edit(embed=embed, view=ListPublicView(int(list_id)))
+            # Discord cannot move a message, so keep active lists at the bottom
+            # by reposting the latest embed and removing the previous active copy.
+            new_msg = await ch.send(embed=embed)
+            new_id = int(new_msg.id)
+            data["message_id"] = new_id
+            data["channel_id"] = int(new_msg.channel.id)
+            LISTS[new_id] = data
+            fresh_embed = await _render_list_embed(guild, data)
+            await new_msg.edit(embed=fresh_embed, view=ListPublicView(new_id))
+            if active_id != new_id:
+                try:
+                    old_msg = await ch.fetch_message(active_id)
+                    await old_msg.delete()
+                except Exception:
+                    pass
     except Exception as e:
         try: print("Failed to update list msg:", e)
         except Exception: pass
+
+async def _bump_active_lists_for_channel(channel_id: int) -> None:
+    seen_data: Set[int] = set()
+    for key, data in list(LISTS.items()):
+        try:
+            if id(data) in seen_data:
+                continue
+            seen_data.add(id(data))
+            if data.get("closed"):
+                continue
+            if int(data.get("channel_id") or 0) != int(channel_id):
+                continue
+            await _update_list_message(int(data.get("message_id") or key))
+        except Exception:
+            continue
 
 async def _list_add_player(list_id: int, uid: int) -> Tuple[bool, str]:
     data = LISTS.get(int(list_id))
@@ -2855,6 +2889,7 @@ class ListPublicView(discord.ui.View):
         msg, next_players = await _list_advance_group(self.list_id)
         if next_players:
             channel_sent, dm_sent = await _list_notify_group(data, next_players)
+            await _update_list_message(self.list_id)
             msg += f" Mentioned next group in channel: {'Yes' if channel_sent else 'No'}; DMed {dm_sent}/{len(next_players)}."
         await interaction.followup.send(msg, ephemeral=True)
 
@@ -2987,7 +3022,7 @@ async def list_cmd(
                 (
                     f"Do you want to run **{act}**?\n"
                     f"If yes, you'll be added to the list in your current queue order.\n"
-                    f"List post: {getattr(msg, 'jump_url', '')}"
+                    "Check the latest list post in the channel for the current group."
                 ).strip(),
                 view=ListDMConfirmView(int(msg.id), int(uid)),
             )

--- a/main.py
+++ b/main.py
@@ -138,6 +138,8 @@ bot = commands.Bot(command_prefix="!", intents=INTENTS)
 SCHEDULES: Dict[int, Dict[str, object]] = {}
 QUEUES: Dict[str, List[int]] = {}
 CHECKED: Dict[str, Set[int]] = {}
+# message_id -> active /list pull state
+LISTS: Dict[int, Dict[str, object]] = {}
 # activity -> users who requested catty/weapon run while queued
 CATTY_RUNS: Dict[str, Set[int]] = {}
 # activity -> { user_id -> cooldown_until_epoch }
@@ -817,6 +819,7 @@ def _chat_help_reply(message_text: str, *, direct_bot_question: bool = False) ->
             "Common commands:\n"
             "• **/join** — join an activity queue\n"
             "• **/queue** — view current queues\n"
+            "• **/list** — Sherpas pull the next ordered group from a queue\n"
             "• **/leave** — leave a queue/signup\n"
             "• **/event** — create a player event signup\n"
             "• **/event_sherpa** — create a Sherpa-only signup\n"
@@ -2392,6 +2395,7 @@ async def on_member_join(member: discord.Member):
                     value=(
                         "• /join — choose an activity to enter its queue (max 2)\n"
                         "• /queue — view current queues or a specific activity\n"
+                        "• /list — Sherpas pull an ordered group from a queue\n"
                         "• /schedule — founder-only: creates the event post and prioritizes queued players"
                     ),
                     inline=False,
@@ -2424,6 +2428,7 @@ async def on_member_join(member: discord.Member):
                 "Commands:\n"
                 "• /join — choose an activity to enter its queue (max 2)\n"
                 "• /queue — view current queues or a specific activity\n"
+                "• /list — Sherpas pull an ordered group from a queue\n"
                 "• /schedule — founder-only: creates an event post and prioritizes queued players\n\n"
                 "What to look for:\n"
                 "• Event posts: 📝 adds you as backup; ✅ tries to join when signups open; ❌ leaves\n"
@@ -2517,8 +2522,434 @@ async def _post_all_activity_boards(fallback_channel_id: Optional[int] = None):
         await _post_activity_board(act, target_channel_id)
 
 # ---------------------------
+# Pull Lists
+# ---------------------------
+
+def _field_value(text: str, limit: int = 1024) -> str:
+    value = str(text or "")
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 3)] + "..."
+
+def _mentions_in_order(user_ids: List[int], *, start_index: int = 1, empty: str = "None yet") -> str:
+    if not user_ids:
+        return empty
+    lines = [f"{idx}. <@{int(uid)}>" for idx, uid in enumerate(user_ids[:35], start=start_index)]
+    if len(user_ids) > 35:
+        lines.append(f"...and {len(user_ids) - 35} more")
+    return _field_value("\n".join(lines))
+
+def _list_player_slots(data: Dict[str, object]) -> int:
+    group_size = max(1, int(data.get("group_size", 1) or 1))
+    sherpa_count = max(0, int(data.get("sherpa_count", 0) or 0))
+    return max(1, group_size - sherpa_count)
+
+def _list_ordered_players(data: Dict[str, object]) -> List[int]:
+    confirmed = {int(uid) for uid in (data.get("confirmed") or [])}
+    ordered: List[int] = []
+    seen: Set[int] = set()
+    for uid in (data.get("source_order") or []):
+        try:
+            uid_int = int(uid)
+        except Exception:
+            continue
+        if uid_int in confirmed and uid_int not in seen:
+            ordered.append(uid_int)
+            seen.add(uid_int)
+    for uid in (data.get("confirmed") or []):
+        try:
+            uid_int = int(uid)
+        except Exception:
+            continue
+        if uid_int not in seen:
+            ordered.append(uid_int)
+            seen.add(uid_int)
+    return ordered
+
+def _list_current_players(data: Dict[str, object]) -> List[int]:
+    players = _list_ordered_players(data)
+    slots = _list_player_slots(data)
+    index = max(0, int(data.get("group_index", 0) or 0))
+    return players[index * slots : (index + 1) * slots]
+
+def _list_current_sherpas(data: Dict[str, object]) -> List[int]:
+    sherpa_count = max(0, int(data.get("sherpa_count", 0) or 0))
+    sherpas = []
+    seen: Set[int] = set()
+    for uid in (data.get("sherpas") or []):
+        try:
+            uid_int = int(uid)
+        except Exception:
+            continue
+        if uid_int not in seen:
+            sherpas.append(uid_int)
+            seen.add(uid_int)
+    return sherpas[:sherpa_count] if sherpa_count else []
+
+def _list_group_count(data: Dict[str, object]) -> int:
+    players = len(_list_ordered_players(data))
+    slots = _list_player_slots(data)
+    current_index = max(0, int(data.get("group_index", 0) or 0))
+    return max(current_index + 1, (players + slots - 1) // slots, 1)
+
+def _list_completed_groups(data: Dict[str, object]) -> Set[int]:
+    try:
+        return {int(x) for x in (data.get("completed_groups") or set())}
+    except Exception:
+        return set()
+
+def _list_host_allowed(interaction: discord.Interaction, data: Dict[str, object]) -> bool:
+    if _is_promoter_or_founder(interaction, data):
+        return True
+    return False
+
+async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, object]) -> discord.Embed:
+    activity = str(data.get("activity") or "Activity")
+    group_size = max(1, int(data.get("group_size", 1) or 1))
+    sherpa_count = max(0, int(data.get("sherpa_count", 0) or 0))
+    player_slots = _list_player_slots(data)
+    ordered_players = _list_ordered_players(data)
+    current_players = _list_current_players(data)
+    current_sherpas = _list_current_sherpas(data)
+    group_index = max(0, int(data.get("group_index", 0) or 0))
+    group_count = _list_group_count(data)
+    completed = group_index in _list_completed_groups(data)
+    declined = {int(uid) for uid in (data.get("declined") or [])}
+    source_order = [int(uid) for uid in (data.get("source_order") or [])]
+    pending = [uid for uid in source_order if uid not in set(ordered_players) and uid not in declined]
+
+    embed = discord.Embed(
+        title=f"Raid List - {activity}",
+        description=(
+            "Queued players were DMed to confirm. Anyone else can press **Join List** below.\n"
+            "Confirmed players are grouped in queue order."
+        ),
+        color=_activity_color(activity),
+    )
+    host_id = data.get("host_id")
+    if host_id:
+        embed.add_field(name="Host", value=f"<@{int(host_id)}>", inline=True)
+    embed.add_field(name="Group Size", value=f"{group_size} total ({player_slots} player + {sherpa_count} sherpa)", inline=True)
+    status = "Completed" if completed else "Active"
+    embed.add_field(name="Current Group", value=f"{group_index + 1} of {group_count} - {status}", inline=True)
+
+    group_start = group_index * player_slots + 1
+    embed.add_field(
+        name=f"Current Players ({len(current_players)}/{player_slots})",
+        value=_mentions_in_order(current_players, start_index=group_start),
+        inline=False,
+    )
+    if sherpa_count:
+        embed.add_field(
+            name=f"Sherpas ({len(current_sherpas)}/{sherpa_count})",
+            value=_mentions_in_order(current_sherpas, empty="Sherpas can press Join List to be listed here."),
+            inline=False,
+        )
+
+    remaining_after_current = ordered_players[(group_index + 1) * player_slots :]
+    if remaining_after_current:
+        embed.add_field(
+            name=f"Up Next ({len(remaining_after_current)})",
+            value=_mentions_in_order(remaining_after_current, start_index=(group_index + 1) * player_slots + 1),
+            inline=False,
+        )
+    else:
+        embed.add_field(name="Up Next", value="No confirmed players waiting yet.", inline=False)
+
+    notified = int(data.get("dm_sent", 0) or 0)
+    failed = int(data.get("dm_failed", 0) or 0)
+    embed.add_field(
+        name=f"Confirmed List ({len(ordered_players)})",
+        value=_mentions_in_order(ordered_players, empty="No yes responses yet."),
+        inline=False,
+    )
+    embed.add_field(
+        name="Queue Responses",
+        value=f"DMed: {notified} | Pending: {len(pending)} | Declined: {len(declined)} | DM failed: {failed}",
+        inline=True,
+    )
+    if guild:
+        try:
+            embed.set_footer(text=f"Use Next Group when this group is done. List ID: {int(data.get('message_id') or 0)}")
+        except Exception:
+            pass
+    return embed
+
+async def _update_list_message(list_id: int) -> None:
+    data = LISTS.get(int(list_id))
+    if not data:
+        return
+    try:
+        ch_id = int(data.get("channel_id") or 0)
+        if not ch_id:
+            return
+        ch = bot.get_channel(ch_id) or await bot.fetch_channel(ch_id)
+        msg = await ch.fetch_message(int(list_id))
+        guild_id = data.get("guild_id")
+        guild = bot.get_guild(int(guild_id)) if guild_id else None
+        embed = await _render_list_embed(guild, data)
+        if data.get("closed"):
+            await msg.edit(embed=embed, view=None)
+        else:
+            await msg.edit(embed=embed, view=ListPublicView(int(list_id)))
+    except Exception as e:
+        try: print("Failed to update list msg:", e)
+        except Exception: pass
+
+async def _list_add_player(list_id: int, uid: int) -> Tuple[bool, str]:
+    data = LISTS.get(int(list_id))
+    if not data or data.get("closed"):
+        return False, "This list is closed."
+    uid = int(uid)
+    sherpas = {int(x) for x in (data.get("sherpas") or [])}
+    confirmed: List[int] = data.get("confirmed") or []  # type: ignore
+    if uid in sherpas:
+        return False, "You're already listed as a Sherpa."
+    if uid in [int(x) for x in confirmed]:
+        return False, "You're already on the list."
+    confirmed.append(uid)
+    data["confirmed"] = confirmed
+    try:
+        declined: Set[int] = data.get("declined") or set()  # type: ignore
+        declined.discard(uid)
+        data["declined"] = declined
+    except Exception:
+        pass
+    await _update_list_message(int(list_id))
+    ordered = _list_ordered_players(data)
+    position = ordered.index(uid) + 1 if uid in ordered else len(ordered)
+    return True, f"You're on the list at position #{position}."
+
+async def _list_add_sherpa(list_id: int, uid: int) -> Tuple[bool, str]:
+    data = LISTS.get(int(list_id))
+    if not data or data.get("closed"):
+        return False, "This list is closed."
+    uid = int(uid)
+    if uid in {int(x) for x in (data.get("confirmed") or [])}:
+        return False, "You're already listed as a player."
+    sherpas: List[int] = data.get("sherpas") or []  # type: ignore
+    if uid in [int(x) for x in sherpas]:
+        return False, "You're already listed as a Sherpa."
+    sherpas.append(uid)
+    data["sherpas"] = sherpas
+    await _update_list_message(int(list_id))
+    return True, "You're listed as a Sherpa for this run."
+
+async def _list_decline(list_id: int, uid: int) -> Tuple[bool, str]:
+    data = LISTS.get(int(list_id))
+    if not data or data.get("closed"):
+        return False, "This list is closed."
+    confirmed: List[int] = data.get("confirmed") or []  # type: ignore
+    data["confirmed"] = [int(x) for x in confirmed if int(x) != int(uid)]
+    declined: Set[int] = data.get("declined") or set()  # type: ignore
+    declined.add(int(uid))
+    data["declined"] = declined
+    await _update_list_message(int(list_id))
+    return True, "No problem. You were marked as not available for this pull."
+
+async def _list_advance_group(list_id: int) -> str:
+    data = LISTS.get(int(list_id))
+    if not data:
+        return "This list no longer exists."
+    group_index = max(0, int(data.get("group_index", 0) or 0))
+    completed = _list_completed_groups(data)
+    current_players = _list_current_players(data)
+    if not current_players:
+        await _update_list_message(int(list_id))
+        return "No confirmed players are in the current group yet."
+    if group_index not in completed:
+        completed.add(group_index)
+        data["completed_groups"] = completed
+        try:
+            await _mark_queue_participants_checked(str(data.get("activity") or ""), current_players)
+        except Exception:
+            pass
+    ordered = _list_ordered_players(data)
+    slots = _list_player_slots(data)
+    data["group_index"] = group_index + 1
+    if len(ordered) > int(data["group_index"]) * slots:
+        msg = f"Moved to group {int(data['group_index']) + 1}."
+    else:
+        msg = f"Group {group_index + 1} marked done. Waiting for more confirmed players."
+    await _update_list_message(int(list_id))
+    return msg
+
+class ListDMConfirmView(discord.ui.View):
+    def __init__(self, list_id: int, uid: int):
+        super().__init__(timeout=12 * 60 * 60)
+        self.list_id = int(list_id)
+        self.uid = int(uid)
+
+    @discord.ui.button(label="Yes, I'm in", style=discord.ButtonStyle.success, custom_id="list_dm_yes")
+    async def yes(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        if int(interaction.user.id) != self.uid:
+            await interaction.response.send_message("This button is not for you.", ephemeral=True)
+            return
+        ok, msg = await _list_add_player(self.list_id, self.uid)
+        await interaction.response.send_message(msg, ephemeral=True)
+
+    @discord.ui.button(label="No", style=discord.ButtonStyle.secondary, custom_id="list_dm_no")
+    async def no(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        if int(interaction.user.id) != self.uid:
+            await interaction.response.send_message("This button is not for you.", ephemeral=True)
+            return
+        ok, msg = await _list_decline(self.list_id, self.uid)
+        await interaction.response.send_message(msg, ephemeral=True)
+
+class ListPublicView(discord.ui.View):
+    def __init__(self, list_id: int):
+        super().__init__(timeout=12 * 60 * 60)
+        self.list_id = int(list_id)
+
+    @discord.ui.button(label="Join List", style=discord.ButtonStyle.primary, custom_id="list_public_join")
+    async def join(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        member = interaction.user if isinstance(interaction.user, discord.Member) else None
+        if member and (_is_sherpa(member) or _is_sherpa_assistant(member)):
+            ok, msg = await _list_add_sherpa(self.list_id, int(interaction.user.id))
+        else:
+            ok, msg = await _list_add_player(self.list_id, int(interaction.user.id))
+        await interaction.response.send_message(msg, ephemeral=True)
+
+    @discord.ui.button(label="Next Group", style=discord.ButtonStyle.success, custom_id="list_public_next")
+    async def next_group(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        data = LISTS.get(self.list_id)
+        if not data or data.get("closed"):
+            await interaction.response.send_message("This list is closed.", ephemeral=True)
+            return
+        if not _list_host_allowed(interaction, data):
+            await interaction.response.send_message("Only the list host or founder can advance groups.", ephemeral=True)
+            return
+        msg = await _list_advance_group(self.list_id)
+        await interaction.response.send_message(msg, ephemeral=True)
+
+    @discord.ui.button(label="Close List", style=discord.ButtonStyle.danger, custom_id="list_public_close")
+    async def close(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        data = LISTS.get(self.list_id)
+        if not data:
+            await interaction.response.send_message("This list is already gone.", ephemeral=True)
+            return
+        if not _list_host_allowed(interaction, data):
+            await interaction.response.send_message("Only the list host or founder can close this list.", ephemeral=True)
+            return
+        data["closed"] = True
+        await _update_list_message(self.list_id)
+        await interaction.response.send_message("List closed.", ephemeral=True)
+
+# ---------------------------
 # Slash Commands
 # ---------------------------
+
+@bot.tree.command(name="list", description="Pull queued players into ordered raid groups")
+@sherpa_host_only()
+@app_commands.describe(
+    activity="Choose the activity queue to pull from",
+    how_many_per_group="Total guardians per group, including sherpas",
+    sherpas="How many sherpas you want in each group",
+)
+@app_commands.autocomplete(activity=_activity_autocomplete)
+async def list_cmd(
+    interaction: discord.Interaction,
+    activity: str,
+    how_many_per_group: int,
+    sherpas: int,
+):
+    await interaction.response.defer(ephemeral=True)
+    guild = interaction.guild
+    if not guild:
+        await interaction.followup.send("Use this in a server.", ephemeral=True)
+        return
+    try:
+        await load_queues()
+        await load_checked()
+        await load_catty()
+    except Exception:
+        pass
+    act, sug = _resolve_activity(activity, list(ALL_ACTIVITIES) + list(QUEUES.keys()))
+    if not act:
+        hint = (" Try: " + ", ".join(sug)) if sug else ""
+        await interaction.followup.send(f"Unknown activity.{hint}", ephemeral=True)
+        return
+    group_size = int(how_many_per_group or 0)
+    sherpa_count = int(sherpas or 0)
+    if group_size < 1 or group_size > 12:
+        await interaction.followup.send("how_many_per_group must be between 1 and 12.", ephemeral=True)
+        return
+    if sherpa_count < 0 or sherpa_count >= group_size:
+        await interaction.followup.send("sherpas must be 0 or more, and less than how_many_per_group.", ephemeral=True)
+        return
+
+    queued_to_prompt = _queue_members_needing_prompt(act)
+    channel = interaction.channel
+    if not channel or not hasattr(channel, "send"):
+        await interaction.followup.send("I could not post the list in this channel.", ephemeral=True)
+        return
+
+    data: Dict[str, object] = {
+        "guild_id": int(guild.id),
+        "channel_id": int(interaction.channel_id or 0),
+        "message_id": 0,
+        "activity": act,
+        "host_id": int(interaction.user.id),
+        "promoter_id": int(interaction.user.id),
+        "group_size": group_size,
+        "sherpa_count": sherpa_count,
+        "source_order": list(queued_to_prompt),
+        "confirmed": [],
+        "declined": set(),
+        "sherpas": [],
+        "group_index": 0,
+        "completed_groups": set(),
+        "dm_sent": 0,
+        "dm_failed": 0,
+        "closed": False,
+    }
+
+    embed = await _render_list_embed(guild, data)
+    try:
+        msg = await channel.send(embed=embed)  # type: ignore[attr-defined]
+    except Exception as e:
+        await interaction.followup.send(f"Could not post the list: {e.__class__.__name__}", ephemeral=True)
+        return
+
+    data["message_id"] = int(msg.id)
+    data["channel_id"] = int(msg.channel.id)
+    LISTS[int(msg.id)] = data
+    try:
+        await msg.edit(view=ListPublicView(int(msg.id)))
+    except Exception:
+        pass
+
+    sent = 0
+    failed = 0
+    for uid in queued_to_prompt:
+        try:
+            member = guild.get_member(int(uid))
+            if member is None:
+                member = await guild.fetch_member(int(uid))
+            dm = await member.create_dm()
+            await dm.send(
+                (
+                    f"Do you want to run **{act}**?\n"
+                    f"If yes, you'll be added to the list in your current queue order.\n"
+                    f"List post: {getattr(msg, 'jump_url', '')}"
+                ).strip(),
+                view=ListDMConfirmView(int(msg.id), int(uid)),
+            )
+            sent += 1
+        except Exception:
+            failed += 1
+    data["dm_sent"] = sent
+    data["dm_failed"] = failed
+    await _update_list_message(int(msg.id))
+
+    skipped_checked = max(0, len(QUEUES.get(act, []) or []) - len(queued_to_prompt))
+    await interaction.followup.send(
+        (
+            f"List posted for **{act}**. DMed {sent} queued player(s); {failed} DM(s) failed."
+            + (f" Skipped {skipped_checked} already-marked queued player(s)." if skipped_checked else "")
+        ),
+        ephemeral=True,
+    )
 
 @bot.tree.command(name="join", description="Join an activity queue")
 @app_commands.describe(

--- a/main.py
+++ b/main.py
@@ -2970,14 +2970,23 @@ async def list_cmd(
         return
 
     queued_to_prompt = _queue_members_needing_prompt(act)
-    channel = interaction.channel
+    target_channel_id = EVENT_SIGNUP_CHANNEL_ID or interaction.channel_id
+    try:
+        channel = bot.get_channel(int(target_channel_id)) if target_channel_id else None
+        if channel is None and target_channel_id:
+            channel = await bot.fetch_channel(int(target_channel_id))
+    except Exception:
+        channel = None
     if not channel or not hasattr(channel, "send"):
-        await interaction.followup.send("I could not post the list in this channel.", ephemeral=True)
+        await interaction.followup.send(
+            "I could not post the list in the raid/dungeon event signup channel.",
+            ephemeral=True,
+        )
         return
 
     data: Dict[str, object] = {
         "guild_id": int(guild.id),
-        "channel_id": int(interaction.channel_id or 0),
+        "channel_id": int(getattr(channel, "id", target_channel_id or 0) or 0),
         "message_id": 0,
         "activity": act,
         "host_id": int(interaction.user.id),
@@ -3022,7 +3031,7 @@ async def list_cmd(
                 (
                     f"Do you want to run **{act}**?\n"
                     f"If yes, you'll be added to the list in your current queue order.\n"
-                    "Check the latest list post in the channel for the current group."
+                    "Check the latest list post in the raid/dungeon event signup channel for the current group."
                 ).strip(),
                 view=ListDMConfirmView(int(msg.id), int(uid)),
             )
@@ -3036,7 +3045,7 @@ async def list_cmd(
     skipped_checked = max(0, len(QUEUES.get(act, []) or []) - len(queued_to_prompt))
     await interaction.followup.send(
         (
-            f"List posted for **{act}**. DMed {sent} queued player(s); {failed} DM(s) failed."
+            f"List posted for **{act}** in <#{int(msg.channel.id)}>. DMed {sent} queued player(s); {failed} DM(s) failed."
             + (f" Skipped {skipped_checked} already-marked queued player(s)." if skipped_checked else "")
         ),
         ephemeral=True,

--- a/main.py
+++ b/main.py
@@ -2670,7 +2670,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
     )
     if guild:
         try:
-            embed.set_footer(text=f"Use Done or Next Group when this group is finished. List ID: {int(data.get('message_id') or 0)}")
+            embed.set_footer(text=f"Use Next Group to ping the next team, or Done to end the list. List ID: {int(data.get('message_id') or 0)}")
         except Exception:
             pass
     return embed
@@ -2747,16 +2747,56 @@ async def _list_decline(list_id: int, uid: int) -> Tuple[bool, str]:
     await _update_list_message(int(list_id))
     return True, "No problem. You were marked as not available for this pull."
 
-async def _list_advance_group(list_id: int) -> str:
+async def _list_notify_group(data: Dict[str, object], user_ids: List[int]) -> Tuple[int, int]:
+    if not user_ids:
+        return 0, 0
+    activity = str(data.get("activity") or "Activity")
+    group_number = max(1, int(data.get("group_index", 0) or 0) + 1)
+    mentions = " ".join(f"<@{int(uid)}>" for uid in user_ids)
+    channel_sent = 0
+    dm_sent = 0
+    try:
+        ch_id = int(data.get("channel_id") or 0)
+        if ch_id:
+            ch = bot.get_channel(ch_id) or await bot.fetch_channel(ch_id)
+            await ch.send(
+                f"Next group for **{activity}** (Group {group_number}): {mentions}",
+                allowed_mentions=discord.AllowedMentions(users=True, roles=False, everyone=False),
+            )
+            channel_sent = 1
+    except Exception as e:
+        try: print("List next-group mention failed:", e)
+        except Exception: pass
+    guild = None
+    try:
+        guild_id = int(data.get("guild_id") or 0)
+        if guild_id:
+            guild = bot.get_guild(guild_id)
+    except Exception:
+        guild = None
+    if guild:
+        for uid in user_ids:
+            try:
+                member = guild.get_member(int(uid))
+                if member is None:
+                    member = await guild.fetch_member(int(uid))
+                dm = await member.create_dm()
+                await dm.send(f"You're up next for **{activity}** (Group {group_number}). Please get ready.")
+                dm_sent += 1
+            except Exception:
+                pass
+    return channel_sent, dm_sent
+
+async def _list_advance_group(list_id: int) -> Tuple[str, List[int]]:
     data = LISTS.get(int(list_id))
     if not data:
-        return "This list no longer exists."
+        return "This list no longer exists.", []
     group_index = max(0, int(data.get("group_index", 0) or 0))
     completed = _list_completed_groups(data)
     current_players = _list_current_players(data)
     if not current_players:
         await _update_list_message(int(list_id))
-        return "No confirmed players are in the current group yet."
+        return "No confirmed players are in the current group yet.", []
     if group_index not in completed:
         completed.add(group_index)
         data["completed_groups"] = completed
@@ -2768,11 +2808,13 @@ async def _list_advance_group(list_id: int) -> str:
     slots = _list_player_slots(data)
     data["group_index"] = group_index + 1
     if len(ordered) > int(data["group_index"]) * slots:
+        next_players = _list_current_players(data)
         msg = f"Moved to group {int(data['group_index']) + 1}."
     else:
+        next_players = []
         msg = f"Group {group_index + 1} marked done. Waiting for more confirmed players."
     await _update_list_message(int(list_id))
-    return msg
+    return msg, next_players
 
 class ListDMConfirmView(discord.ui.View):
     def __init__(self, list_id: int, uid: int):
@@ -2809,8 +2851,24 @@ class ListPublicView(discord.ui.View):
         if not _list_host_allowed(interaction, data):
             await interaction.response.send_message("Only the list host or founder can advance groups.", ephemeral=True)
             return
-        msg = await _list_advance_group(self.list_id)
-        await interaction.response.send_message(msg, ephemeral=True)
+        await interaction.response.defer(ephemeral=True)
+        msg, next_players = await _list_advance_group(self.list_id)
+        if next_players:
+            channel_sent, dm_sent = await _list_notify_group(data, next_players)
+            msg += f" Mentioned next group in channel: {'Yes' if channel_sent else 'No'}; DMed {dm_sent}/{len(next_players)}."
+        await interaction.followup.send(msg, ephemeral=True)
+
+    async def _close_from_button(self, interaction: discord.Interaction) -> None:
+        data = LISTS.get(self.list_id)
+        if not data:
+            await interaction.response.send_message("This list is already gone.", ephemeral=True)
+            return
+        if not _list_host_allowed(interaction, data):
+            await interaction.response.send_message("Only the list host or founder can close this list.", ephemeral=True)
+            return
+        data["closed"] = True
+        await _update_list_message(self.list_id)
+        await interaction.response.send_message("List ended.", ephemeral=True)
 
     @discord.ui.button(label="Join List", style=discord.ButtonStyle.primary, custom_id="list_public_join")
     async def join(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
@@ -2823,7 +2881,7 @@ class ListPublicView(discord.ui.View):
 
     @discord.ui.button(label="Done", style=discord.ButtonStyle.success, custom_id="list_public_done")
     async def done(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
-        await self._advance_from_button(interaction)
+        await self._close_from_button(interaction)
 
     @discord.ui.button(label="Next Group", style=discord.ButtonStyle.success, custom_id="list_public_next")
     async def next_group(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
@@ -2831,16 +2889,7 @@ class ListPublicView(discord.ui.View):
 
     @discord.ui.button(label="Close List", style=discord.ButtonStyle.danger, custom_id="list_public_close")
     async def close(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
-        data = LISTS.get(self.list_id)
-        if not data:
-            await interaction.response.send_message("This list is already gone.", ephemeral=True)
-            return
-        if not _list_host_allowed(interaction, data):
-            await interaction.response.send_message("Only the list host or founder can close this list.", ephemeral=True)
-            return
-        data["closed"] = True
-        await _update_list_message(self.list_id)
-        await interaction.response.send_message("List closed.", ephemeral=True)
+        await self._close_from_button(interaction)
 
 # ---------------------------
 # Slash Commands

--- a/main.py
+++ b/main.py
@@ -2670,7 +2670,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
     )
     if guild:
         try:
-            embed.set_footer(text=f"Use Next Group when this group is done. List ID: {int(data.get('message_id') or 0)}")
+            embed.set_footer(text=f"Use Done or Next Group when this group is finished. List ID: {int(data.get('message_id') or 0)}")
         except Exception:
             pass
     return embed
@@ -2801,17 +2801,7 @@ class ListPublicView(discord.ui.View):
         super().__init__(timeout=12 * 60 * 60)
         self.list_id = int(list_id)
 
-    @discord.ui.button(label="Join List", style=discord.ButtonStyle.primary, custom_id="list_public_join")
-    async def join(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
-        member = interaction.user if isinstance(interaction.user, discord.Member) else None
-        if member and (_is_sherpa(member) or _is_sherpa_assistant(member)):
-            ok, msg = await _list_add_sherpa(self.list_id, int(interaction.user.id))
-        else:
-            ok, msg = await _list_add_player(self.list_id, int(interaction.user.id))
-        await interaction.response.send_message(msg, ephemeral=True)
-
-    @discord.ui.button(label="Next Group", style=discord.ButtonStyle.success, custom_id="list_public_next")
-    async def next_group(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+    async def _advance_from_button(self, interaction: discord.Interaction) -> None:
         data = LISTS.get(self.list_id)
         if not data or data.get("closed"):
             await interaction.response.send_message("This list is closed.", ephemeral=True)
@@ -2821,6 +2811,23 @@ class ListPublicView(discord.ui.View):
             return
         msg = await _list_advance_group(self.list_id)
         await interaction.response.send_message(msg, ephemeral=True)
+
+    @discord.ui.button(label="Join List", style=discord.ButtonStyle.primary, custom_id="list_public_join")
+    async def join(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        member = interaction.user if isinstance(interaction.user, discord.Member) else None
+        if member and (_is_sherpa(member) or _is_sherpa_assistant(member)):
+            ok, msg = await _list_add_sherpa(self.list_id, int(interaction.user.id))
+        else:
+            ok, msg = await _list_add_player(self.list_id, int(interaction.user.id))
+        await interaction.response.send_message(msg, ephemeral=True)
+
+    @discord.ui.button(label="Done", style=discord.ButtonStyle.success, custom_id="list_public_done")
+    async def done(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        await self._advance_from_button(interaction)
+
+    @discord.ui.button(label="Next Group", style=discord.ButtonStyle.success, custom_id="list_public_next")
+    async def next_group(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]
+        await self._advance_from_button(interaction)
 
     @discord.ui.button(label="Close List", style=discord.ButtonStyle.danger, custom_id="list_public_close")
     async def close(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore[override]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `/list` for Sherpas to pull queued players into ordered activity groups.
- Post the interactive list embed in the raid/dungeon event signup channel, with Join List, Done, Next Group, and Close List buttons.
- DM unmarked queued players for yes/no confirmation and keep confirmed players in queue order.
- Make Next Group mark the current group complete, move forward, mention the next group in-channel, and DM those players.
- Make Done end/close the list instead of advancing groups.
- Keep active list embeds at the bottom of the event signup channel by reposting updates until the list is closed.

## Testing
- `python3 -m py_compile main.py`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f839881-a00e-420a-9a8e-c5d6c550c20b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f839881-a00e-420a-9a8e-c5d6c550c20b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

