### PR TITLE
Add /list command for back-to-back marathon queue runs

### DIFF
--- a/main.py
+++ b/main.py
@@ -3673,7 +3673,7 @@ def _parse_user_ids(text: str, guild: Optional[discord.Guild]) -> List[int]:
 # /list command — helpers & views (standalone; does not use SCHEDULES or ConfirmView)
 # ---------------------------
 
-LIST_JOIN_EMOJI = "✅"
+LIST_JOIN_EMOJI = "📋"
 
 def _list_run_sherpa_slots_needed(data: Dict[str, object], player_count: int) -> int:
     """Sherpa slots per group. Host always reserves 1 fireteam slot."""
@@ -3695,6 +3695,22 @@ def _list_max_group_size(data: Dict[str, object]) -> int:
         return max(1, cap - host_slots - max(0, int(explicit)))
     return max(1, cap - host_slots)
 
+def _list_rebuild_waiting_with_priority(
+    pulled: List[int],
+    waiting: List[int],
+    activity: str,
+) -> List[int]:
+    """Queue members in waiting sort ahead of react/open joiners."""
+    q = [int(u) for u in (QUEUES.get(activity, []) or [])]
+    queue_positions = {u: i for i, u in enumerate(q)}
+    queue_waiting = [int(u) for u in waiting if int(u) in queue_positions]
+    open_waiting = [int(u) for u in waiting if int(u) not in queue_positions]
+    queue_waiting.sort(key=lambda u: queue_positions[int(u)])
+    # Preserve join order among open (react) joiners
+    open_order = {int(u): i for i, u in enumerate(waiting) if int(u) not in queue_positions}
+    open_waiting.sort(key=lambda u: open_order.get(int(u), 0))
+    return list(pulled) + queue_waiting + open_waiting
+
 async def _list_try_add_to_line(
     guild: Optional[discord.Guild],
     session_id: str,
@@ -3704,7 +3720,8 @@ async def _list_try_add_to_line(
     if not data or str(data.get("status")) == "done":
         return False, "This list is no longer active."
     line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
-    if int(uid) in line:
+    uid = int(uid)
+    if uid in line:
         return False, "You're already in line."
     max_size = data.get("max_list_size")
     if max_size is not None:
@@ -3715,14 +3732,28 @@ async def _list_try_add_to_line(
         except Exception:
             pass
     declined: Set[int] = set(int(x) for x in (data.get("declined") or set()))  # type: ignore[arg-type]
-    if int(uid) in declined:
-        declined.discard(int(uid))
+    if uid in declined:
+        declined.discard(uid)
         data["declined"] = declined
-    line.append(int(uid))
-    data["line"] = line
+
+    activity = str(data.get("activity") or "")
+    try:
+        await load_queues()
+    except Exception:
+        pass
+
+    next_index = int(data.get("next_index", 0) or 0)
+    pulled = line[:next_index]
+    waiting = list(line[next_index:])
+    waiting.append(uid)
+    data["line"] = _list_rebuild_waiting_with_priority(pulled, waiting, activity)
+
+    on_queue = uid in {int(u) for u in (QUEUES.get(activity, []) or [])}
     if guild:
         await _update_list_control_message(guild, session_id)
-    return True, "You're in line! We'll DM you when it's your turn."
+    if on_queue:
+        return True, "You're in line with **queue priority**! We'll DM you when it's your turn."
+    return True, "You're in line! Queue members are ahead of react joiners — we'll DM you when it's your turn."
 
 async def _list_add_join_reaction(message: Optional[discord.Message]) -> None:
     if not message:
@@ -3806,6 +3837,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
         desc = (
             f"**/list** session for **{activity}** — running it back-to-back.\n"
             f"React {LIST_JOIN_EMOJI} on this post (or tap **Yes** in DMs) to join the line.\n"
+            f"**Queue members get priority** over {LIST_JOIN_EMOJI} joiners.\n"
             f"Each group: **host** + **{group_size}** player(s) + {sherpa_note} (fireteam **{cap}**)."
         )
     embed = discord.Embed(title=title, description=desc, color=_activity_color(activity))
@@ -3836,9 +3868,15 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
     embed.add_field(name="Waiting", value=str(len(waiting)), inline=True)
 
     if waiting:
-        lines = [f"{next_index + i + 1}. <@{uid}>" for i, uid in enumerate(waiting[:20])]
+        q_order = {int(u): i for i, u in enumerate(QUEUES.get(activity, []) or [])}
+        lines = []
+        for i, uid in enumerate(waiting[:20]):
+            pos = next_index + i + 1
+            tag = " 🎫" if int(uid) in q_order else ""
+            lines.append(f"{pos}. <@{uid}>{tag}")
         extra = f"\n…and {len(waiting) - 20} more" if len(waiting) > 20 else ""
-        embed.add_field(name="Up Next", value="\n".join(lines) + extra, inline=False)
+        note = "\n🎫 = on activity queue (priority)"
+        embed.add_field(name="Up Next", value="\n".join(lines) + extra + note, inline=False)
     elif status != "done":
         embed.add_field(name="Up Next", value="_No one left in line._", inline=False)
 

--- a/main.py
+++ b/main.py
@@ -3727,6 +3727,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
     group_size = int(data.get("group_size", 1) or 1)
     cap = int(data.get("capacity", 0) or 0)
     batch_no = int(data.get("batch_number", 0) or 0)
+    round_no = int(data.get("round_number", 1) or 1)
     status = str(data.get("status") or "active")
     line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
     next_index = int(data.get("next_index", 0) or 0)
@@ -3751,6 +3752,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
     if host_id:
         embed.add_field(name="Hosted by", value=f"<@{int(host_id)}>", inline=True)
     embed.add_field(name="Batches Run", value=str(batch_no), inline=True)
+    embed.add_field(name="Round", value=str(round_no), inline=True)
     embed.add_field(name="In Line", value=str(len(line)), inline=True)
     embed.add_field(name="Waiting", value=str(len(waiting)), inline=True)
 
@@ -3770,7 +3772,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
         )
 
     if status == "active":
-        embed.set_footer(text="List command • Next pulls the next group • Done ends this list")
+        embed.set_footer(text="List command • Next pulls the next group (cycles the line) • Done ends this list")
 
     try:
         img_url = data.get("image_url")
@@ -3984,15 +3986,32 @@ class ListControlView(discord.ui.View):
         await interaction.response.defer(ephemeral=True)
         guild = interaction.guild
         line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
+        if not line:
+            await interaction.followup.send(
+                "No one has joined the line yet. Players tap **Yes** in their DMs first.",
+                ephemeral=True,
+            )
+            return
+
         next_index = int(data.get("next_index", 0) or 0)
         group_size = max(1, int(data.get("group_size", 1) or 1))
         waiting = line[next_index:]
+        wrapped_round = False
         if not waiting:
-            await interaction.followup.send("No one left in line.", ephemeral=True)
-            return
+            # End of line — start another lap so Next can be used over and over
+            data["next_index"] = 0
+            data["round_number"] = int(data.get("round_number", 1) or 1) + 1
+            next_index = 0
+            waiting = line[:]
+            wrapped_round = True
+
         batch_players = waiting[:group_size]
         new_index = next_index + len(batch_players)
-        data["next_index"] = new_index
+        # If this batch finishes the line, next click wraps to round+1
+        if new_index >= len(line):
+            data["next_index"] = len(line)
+        else:
+            data["next_index"] = new_index
         sherpa_count = _list_run_sherpa_slots_needed(data, len(batch_players))
         sherpas = _pick_sherpas_for_batch(guild, data, sherpa_count)
         activity = str(data.get("activity") or "Activity")
@@ -4034,11 +4053,12 @@ class ListControlView(discord.ui.View):
                 pass
 
         await _update_list_control_message(guild, self.session_id)
-        await _repost_list_to_bottom(guild, self.session_id)
+        round_no = int(data.get("round_number", 1) or 1)
+        lap_note = f" (round {round_no})" if wrapped_round else ""
         await interaction.followup.send(
-            f"Pulled group {batch_no}: {len(batch_players)} player(s)"
+            f"Pulled group {batch_no}{lap_note}: {len(batch_players)} player(s)"
             + (f" + {len(sherpas)} Sherpa(s)" if sherpas else "")
-            + ".",
+            + ". Hit **Next** again whenever you're ready for the next group.",
             ephemeral=True,
         )
 
@@ -5181,6 +5201,7 @@ async def list_cmd(
             "sherpa_index": 0,
             "status": "active",
             "batch_number": 0,
+            "round_number": 1,
             "sherpa_alert_message_id": None,
             "sherpa_alert_channel_id": None,
         }
@@ -5453,9 +5474,9 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
     # Normalize emoji to string once
     emoji_str = str(payload.emoji)
 
-    # List-run Sherpa signup (✅ on sherpa alert for /list marathon)
+    # /list Sherpa signup (✅ on sherpa alert — separate from /schedule sherpa posts)
     for session_id, data in list(LIST_SESSIONS.items()):
-        if str(data.get("status")) == "done":
+        if str(data.get("type")) != "list_run" or str(data.get("status")) == "done":
             continue
         alert_id = int(data.get("sherpa_alert_message_id")) if data.get("sherpa_alert_message_id") else None
         alert_ch = int(data.get("sherpa_alert_channel_id")) if data.get("sherpa_alert_channel_id") else None

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # GoonBot main.py — queues, check-in, promotions, scheduling
 # Exact behavior:
+# - /list is a separate command from /schedule: its own sessions (LIST_SESSIONS), DMs, embed, and Next/Done controls
 # - Main Event Embed -> EVENT_SIGNUP_CHANNEL_ID (aka RAID_DUNGEON_EVENT_SIGNUP_CHANNEL_ID)
 # - Sherpa Signup Embed -> RAID_SIGN_UP_CHANNEL_ID (✅ to claim Sherpa; overflow -> Sherpa Backup)
 # - Sherpa Announcement -> GENERAL_SHERPA_CHANNEL_ID (pings SHERPA_ROLE_ID if set; points to Sherpa signup post)
@@ -137,7 +138,7 @@ bot = commands.Bot(command_prefix="!", intents=INTENTS)
 # ---------------------------
 
 SCHEDULES: Dict[int, Dict[str, object]] = {}
-# Active /list marathon sessions keyed by stable session id
+# Active /list sessions (separate from SCHEDULES — not events, not schedule DMs)
 LIST_SESSIONS: Dict[str, Dict[str, object]] = {}
 LIST_RUNS_BY_CHANNEL: Dict[int, str] = {}
 LIST_RUNS_MSG_TO_SESSION: Dict[int, str] = {}
@@ -2172,6 +2173,18 @@ def founder_only():
         raise app_commands.CheckFailure("You are not authorized to use this command.")
     return app_commands.check(predicate)
 
+def _is_list_host_or_founder(interaction: discord.Interaction, data: Optional[Dict[str, object]] = None) -> bool:
+    """Permission check for /list controls only (not shared with /schedule)."""
+    try:
+        uid = int(interaction.user.id)
+        if FOUNDER_USER_ID and uid == int(FOUNDER_USER_ID):
+            return True
+        if data and data.get("type") == "list_run" and data.get("host_id") and int(data["host_id"]) == uid:  # type: ignore[arg-type]
+            return True
+    except Exception:
+        pass
+    return False
+
 def _is_promoter_or_founder(interaction: discord.Interaction, data: Optional[Dict[str, object]] = None) -> bool:
     try:
         uid = int(interaction.user.id)
@@ -2416,7 +2429,8 @@ async def on_member_join(member: discord.Member):
                     value=(
                         "• /join — choose an activity to enter its queue (max 2)\n"
                         "• /queue — view current queues or a specific activity\n"
-                        "• /schedule — founder-only: creates the event post and prioritizes queued players"
+                        "• /schedule — founder-only: creates a one-time scheduled event from the queue\n"
+                        "• /list — founder-only: repeat runs with a line, Next/Done groups, and Sherpa fill"
                     ),
                     inline=False,
                 )
@@ -2448,7 +2462,8 @@ async def on_member_join(member: discord.Member):
                 "Commands:\n"
                 "• /join — choose an activity to enter its queue (max 2)\n"
                 "• /queue — view current queues or a specific activity\n"
-                "• /schedule — founder-only: creates an event post and prioritizes queued players\n\n"
+                "• /schedule — founder-only: creates a one-time scheduled event from the queue\n"
+                "• /list — founder-only: repeat runs with a line, Next/Done groups, and Sherpa fill\n\n"
                 "What to look for:\n"
                 "• Event posts: 📝 adds you as backup; ✅ tries to join when signups open; ❌ leaves\n"
                 "• DMs for confirmations and reminders (2h/30m/start); you can reply here with questions"
@@ -3655,7 +3670,7 @@ def _parse_user_ids(text: str, guild: Optional[discord.Guild]) -> List[int]:
     return unique_ids
 
 # ---------------------------
-# List Run (/list marathon) helpers & views
+# /list command — helpers & views (standalone; does not use SCHEDULES or ConfirmView)
 # ---------------------------
 
 def _list_run_sherpa_slots_needed(data: Dict[str, object], player_count: int) -> int:
@@ -3717,14 +3732,14 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
     next_index = int(data.get("next_index", 0) or 0)
     waiting = line[next_index:]
     completed_batches: List[List[int]] = list(data.get("completed_batches") or [])  # type: ignore[arg-type]
-    promoter_id = data.get("promoter_id")
+    host_id = data.get("host_id") or data.get("promoter_id")
 
-    title = f"📋 List Run — {activity}"
+    title = f"📋 List — {activity}"
     if status == "done":
-        desc = "This list run is **finished**. Thanks everyone!"
+        desc = "This **/list** session is **finished**. Thanks everyone!"
     else:
         desc = (
-            f"We're running **{activity}** back-to-back today.\n"
+            f"**/list** session for **{activity}** — running it back-to-back.\n"
             f"Players go in groups of **{group_size}**; remaining fireteam slots are filled with **Sherpas**."
         )
     embed = discord.Embed(title=title, description=desc, color=_activity_color(activity))
@@ -3733,8 +3748,8 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
         embed.add_field(name="Difficulty", value=str(data.get("difficulty")), inline=True)
     embed.add_field(name="Group Size", value=str(group_size), inline=True)
     embed.add_field(name="Fireteam Size", value=str(cap), inline=True)
-    if promoter_id:
-        embed.add_field(name="Hosted by", value=f"<@{int(promoter_id)}>", inline=True)
+    if host_id:
+        embed.add_field(name="Hosted by", value=f"<@{int(host_id)}>", inline=True)
     embed.add_field(name="Batches Run", value=str(batch_no), inline=True)
     embed.add_field(name="In Line", value=str(len(line)), inline=True)
     embed.add_field(name="Waiting", value=str(len(waiting)), inline=True)
@@ -3755,7 +3770,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
         )
 
     if status == "active":
-        embed.set_footer(text="Use Next to pull the next group • Done ends this list run")
+        embed.set_footer(text="List command • Next pulls the next group • Done ends this list")
 
     try:
         img_url = data.get("image_url")
@@ -3963,8 +3978,8 @@ class ListControlView(discord.ui.View):
         if not data or str(data.get("status")) == "done":
             await interaction.response.send_message("This list run is no longer active.", ephemeral=True)
             return
-        if not _is_promoter_or_founder(interaction, data):
-            await interaction.response.send_message("Only the host or a founder can advance the list.", ephemeral=True)
+        if not _is_list_host_or_founder(interaction, data):
+            await interaction.response.send_message("Only the list host or a founder can advance the list.", ephemeral=True)
             return
         await interaction.response.defer(ephemeral=True)
         guild = interaction.guild
@@ -4018,13 +4033,6 @@ class ListControlView(discord.ui.View):
             except Exception:
                 pass
 
-        try:
-            act = str(data.get("activity") or "")
-            if act:
-                await _mark_queue_participants_checked(act, batch_players)
-        except Exception:
-            pass
-
         await _update_list_control_message(guild, self.session_id)
         await _repost_list_to_bottom(guild, self.session_id)
         await interaction.followup.send(
@@ -4039,8 +4047,8 @@ class ListControlView(discord.ui.View):
         if not data:
             await interaction.response.send_message("This list run is no longer active.", ephemeral=True)
             return
-        if not _is_promoter_or_founder(interaction, data):
-            await interaction.response.send_message("Only the host or a founder can end the list.", ephemeral=True)
+        if not _is_list_host_or_founder(interaction, data):
+            await interaction.response.send_message("Only the list host or a founder can end the list.", ephemeral=True)
             return
         data["status"] = "done"
         channel_id = int(data.get("channel_id") or 0)
@@ -5035,12 +5043,12 @@ async def schedule_cmd(
                 pass
 
 # ---------------------------
-# /list — marathon list run (batch queue with Next/Done controls)
+# /list — standalone repeat-run command (not /schedule)
 # ---------------------------
 
 @bot.tree.command(
     name="list",
-    description="(Founder) Start a back-to-back list run: DM queue, line up players, pull groups with Next/Done",
+    description="(Founder) Run an activity on repeat: DM the queue, line people up, pull groups with Next/Done",
 )
 @founder_only()
 @app_commands.describe(
@@ -5151,8 +5159,9 @@ async def list_cmd(
                         pass
 
         session_id = uuid.uuid4().hex[:12]
-        promoter_id = interaction.user.id
+        host_id = interaction.user.id
         data: Dict[str, object] = {
+            "type": "list_run",
             "session_id": session_id,
             "guild_id": guild.id if guild else None,
             "activity": act,
@@ -5163,7 +5172,7 @@ async def list_cmd(
             "capacity": cap,
             "group_size": batch_players,
             "channel_id": channel_id,
-            "promoter_id": promoter_id,
+            "host_id": host_id,
             "line": [],
             "declined": set(),
             "next_index": 0,
@@ -5212,7 +5221,7 @@ async def list_cmd(
         if RAID_SIGN_UP_CHANNEL_ID and sherpa_slots > 0:
             try:
                 sherpa_embed = discord.Embed(
-                    title=f"🧭 Sherpa Signup — List Run: {act}",
+                    title=f"🧭 Sherpa Signup — /list: {act}",
                     description=(
                         f"We're running **{act}** back-to-back at {when_text}.\n"
                         f"React ✅ to join the Sherpa rotation (fills remaining fireteam slots)."
@@ -5256,9 +5265,9 @@ async def list_cmd(
                 print("List DM failed:", e)
 
         status_lines = [
-            f"Started list run for **{act}**" + (f" ({selected_difficulty})" if selected_difficulty else "") + ".",
-            f"DMed **{sent}** queued player(s).",
-            f"Control embed posted in <#{channel_id}> (stays at the bottom until **Done**).",
+            f"**/list** started for **{act}**" + (f" ({selected_difficulty})" if selected_difficulty else "") + ".",
+            f"DMed **{sent}** queued player(s) to join the line.",
+            f"List embed posted in <#{channel_id}> (stays at the bottom until **Done**).",
             f"Group size: **{batch_players}** | Fireteam: **{cap}** | Sherpas per group: **{sherpa_slots}**.",
         ]
         if difficulty and not is_raid_dungeon:

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import os
 import asyncio
 import json
 import re
+import uuid
 from datetime import datetime, timedelta
 import datetime as datetime_module
 from typing import Dict, List, Optional, Set, Tuple
@@ -136,6 +137,11 @@ bot = commands.Bot(command_prefix="!", intents=INTENTS)
 # ---------------------------
 
 SCHEDULES: Dict[int, Dict[str, object]] = {}
+# Active /list marathon sessions keyed by stable session id
+LIST_SESSIONS: Dict[str, Dict[str, object]] = {}
+LIST_RUNS_BY_CHANNEL: Dict[int, str] = {}
+LIST_RUNS_MSG_TO_SESSION: Dict[int, str] = {}
+LIST_REPOST_DEBOUNCE: Dict[int, float] = {}
 QUEUES: Dict[str, List[int]] = {}
 CHECKED: Dict[str, Set[int]] = {}
 # activity -> users who requested catty/weapon run while queued
@@ -404,6 +410,7 @@ async def _send_to_channel_id(
     embed: Optional[discord.Embed] = None,
     file: Optional[discord.File] = None,
     allowed_mentions: Optional[discord.AllowedMentions] = None,
+    view: Optional[discord.ui.View] = None,
 ):
     try:
         if not channel_id:
@@ -411,11 +418,16 @@ async def _send_to_channel_id(
         ch = bot.get_channel(int(channel_id)) or await bot.fetch_channel(int(channel_id))
         if not ch:
             return None
+        kwargs: Dict[str, object] = {}
+        if allowed_mentions is not None:
+            kwargs["allowed_mentions"] = allowed_mentions
+        if view is not None:
+            kwargs["view"] = view
         if file and embed:
-            return await ch.send(content=content, embed=embed, file=file, allowed_mentions=allowed_mentions)
+            return await ch.send(content=content, embed=embed, file=file, **kwargs)  # type: ignore[arg-type]
         if embed:
-            return await ch.send(content=content, embed=embed, allowed_mentions=allowed_mentions)
-        return await ch.send(content=content, allowed_mentions=allowed_mentions)
+            return await ch.send(content=content, embed=embed, **kwargs)  # type: ignore[arg-type]
+        return await ch.send(content=content, **kwargs)  # type: ignore[arg-type]
     except Exception as e:
         try: print("_send_to_channel_id error:", channel_id, e)
         except Exception: pass
@@ -2362,6 +2374,18 @@ async def on_ready():
         bot._sched_task = bot.loop.create_task(_scheduler_loop())  # type: ignore[attr-defined]
     if not getattr(bot, "_autosave_task", None):
         bot._autosave_task = bot.loop.create_task(_autosave_loop())  # type: ignore[attr-defined]
+    if not getattr(bot, "_list_views_registered", False):
+        try:
+            for session_id, data in list(LIST_SESSIONS.items()):
+                if str(data.get("status")) == "done":
+                    continue
+                _register_list_views(str(session_id), list(data.get("line") or []))  # type: ignore[arg-type]
+            bot._list_views_registered = True  # type: ignore[attr-defined]
+        except Exception as e:
+            try:
+                print("List view registration failed:", e)
+            except Exception:
+                pass
     print(f"Ready as {bot.user}")
 
 # ---------------------------
@@ -2444,6 +2468,10 @@ async def on_message(message: discord.Message):
         channel_id = getattr(message.channel, "id", None)
         if not channel_id:
             return
+
+        if EVENT_SIGNUP_CHANNEL_ID and int(channel_id) == int(EVENT_SIGNUP_CHANNEL_ID):
+            await _maybe_repost_list_control(int(channel_id))
+
         if int(channel_id) not in _help_channel_ids():
             return
 
@@ -3627,6 +3655,405 @@ def _parse_user_ids(text: str, guild: Optional[discord.Guild]) -> List[int]:
     return unique_ids
 
 # ---------------------------
+# List Run (/list marathon) helpers & views
+# ---------------------------
+
+def _list_run_sherpa_slots_needed(data: Dict[str, object], player_count: int) -> int:
+    cap = int(data.get("capacity", 0) or 0)
+    return max(0, cap - int(player_count))
+
+def _guild_sherpa_member_ids(guild: Optional[discord.Guild]) -> List[int]:
+    if not guild:
+        return []
+    out: List[int] = []
+    seen: Set[int] = set()
+    for member in guild.members:
+        try:
+            if _is_sherpa(member) or _is_sherpa_assistant(member):
+                if member.id not in seen:
+                    out.append(int(member.id))
+                    seen.add(int(member.id))
+        except Exception:
+            continue
+    return out
+
+def _pick_sherpas_for_batch(guild: Optional[discord.Guild], data: Dict[str, object], count: int) -> List[int]:
+    if count <= 0:
+        return []
+    pool: List[int] = list(data.get("sherpa_pool") or [])  # type: ignore[arg-type]
+    idx = int(data.get("sherpa_index", 0) or 0)
+    picked: List[int] = []
+    seen: Set[int] = set()
+    # Prefer registered sherpa pool (round-robin)
+    attempts = 0
+    while len(picked) < count and pool and attempts < len(pool) * 2:
+        uid = int(pool[idx % len(pool)])
+        idx += 1
+        attempts += 1
+        if uid in seen:
+            continue
+        seen.add(uid)
+        picked.append(uid)
+    # Fill any remaining slots from guild Sherpa roles
+    if len(picked) < count and guild:
+        for uid in _guild_sherpa_member_ids(guild):
+            if uid in seen:
+                continue
+            seen.add(uid)
+            picked.append(uid)
+            if len(picked) >= count:
+                break
+    data["sherpa_index"] = idx
+    return picked
+
+async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, object]) -> Tuple[discord.Embed, Optional[discord.File]]:
+    activity = str(data.get("activity") or "Activity")
+    when = str(data.get("when_text") or "TBD")
+    group_size = int(data.get("group_size", 1) or 1)
+    cap = int(data.get("capacity", 0) or 0)
+    batch_no = int(data.get("batch_number", 0) or 0)
+    status = str(data.get("status") or "active")
+    line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
+    next_index = int(data.get("next_index", 0) or 0)
+    waiting = line[next_index:]
+    completed_batches: List[List[int]] = list(data.get("completed_batches") or [])  # type: ignore[arg-type]
+    promoter_id = data.get("promoter_id")
+
+    title = f"📋 List Run — {activity}"
+    if status == "done":
+        desc = "This list run is **finished**. Thanks everyone!"
+    else:
+        desc = (
+            f"We're running **{activity}** back-to-back today.\n"
+            f"Players go in groups of **{group_size}**; remaining fireteam slots are filled with **Sherpas**."
+        )
+    embed = discord.Embed(title=title, description=desc, color=_activity_color(activity))
+    embed.add_field(name="When", value=when, inline=False)
+    if data.get("difficulty"):
+        embed.add_field(name="Difficulty", value=str(data.get("difficulty")), inline=True)
+    embed.add_field(name="Group Size", value=str(group_size), inline=True)
+    embed.add_field(name="Fireteam Size", value=str(cap), inline=True)
+    if promoter_id:
+        embed.add_field(name="Hosted by", value=f"<@{int(promoter_id)}>", inline=True)
+    embed.add_field(name="Batches Run", value=str(batch_no), inline=True)
+    embed.add_field(name="In Line", value=str(len(line)), inline=True)
+    embed.add_field(name="Waiting", value=str(len(waiting)), inline=True)
+
+    if waiting:
+        lines = [f"{next_index + i + 1}. <@{uid}>" for i, uid in enumerate(waiting[:20])]
+        extra = f"\n…and {len(waiting) - 20} more" if len(waiting) > 20 else ""
+        embed.add_field(name="Up Next", value="\n".join(lines) + extra, inline=False)
+    elif status != "done":
+        embed.add_field(name="Up Next", value="_No one left in line._", inline=False)
+
+    if completed_batches:
+        last = completed_batches[-1]
+        embed.add_field(
+            name="Last Group",
+            value=", ".join(f"<@{uid}>" for uid in last) or "—",
+            inline=False,
+        )
+
+    if status == "active":
+        embed.set_footer(text="Use Next to pull the next group • Done ends this list run")
+
+    try:
+        img_url = data.get("image_url")
+        if img_url and not str(img_url).startswith("attachment://"):
+            embed.set_image(url=str(img_url))
+            return embed, None
+    except Exception:
+        pass
+    return _apply_activity_image(embed, activity)
+
+def _list_session_data(session_id: str) -> Optional[Dict[str, object]]:
+    return LIST_SESSIONS.get(str(session_id))
+
+def _list_control_message_id(data: Dict[str, object]) -> Optional[int]:
+    try:
+        mid = data.get("control_message_id")
+        return int(mid) if mid else None
+    except Exception:
+        return None
+
+def _register_list_views(session_id: str, line_user_ids: Optional[List[int]] = None) -> None:
+    sid = str(session_id)
+    try:
+        bot.add_view(ListControlView(session_id=sid))
+    except Exception:
+        pass
+    if line_user_ids:
+        for uid in line_user_ids:
+            try:
+                bot.add_view(ListConfirmView(session_id=sid, uid=int(uid)))
+            except Exception:
+                pass
+
+async def _update_list_control_message(guild: Optional[discord.Guild], session_id: str) -> None:
+    data = _list_session_data(session_id)
+    if not data or not guild:
+        return
+    mid = _list_control_message_id(data)
+    channel_id = int(data.get("channel_id") or 0)
+    if not mid or not channel_id:
+        return
+    channel = guild.get_channel(channel_id) or await guild.fetch_channel(channel_id)
+    if not channel:
+        return
+    try:
+        msg = await channel.fetch_message(int(mid))
+    except Exception:
+        return
+    embed, _ = await _render_list_embed(guild, data)
+    view = None if str(data.get("status")) == "done" else ListControlView(session_id=str(session_id))
+    try:
+        await msg.edit(embed=embed, view=view)
+    except Exception:
+        pass
+
+async def _repost_list_to_bottom(guild: Optional[discord.Guild], session_id: str) -> Optional[int]:
+    data = _list_session_data(session_id)
+    if not data or not guild or str(data.get("status")) == "done":
+        return None
+    channel_id = int(data.get("channel_id") or 0)
+    old_mid = _list_control_message_id(data)
+    if not channel_id:
+        return None
+    channel = guild.get_channel(channel_id) or await guild.fetch_channel(channel_id)
+    if not channel:
+        return None
+    embed, f = await _render_list_embed(guild, data)
+    view = ListControlView(session_id=str(session_id))
+    if old_mid:
+        try:
+            old_msg = await channel.fetch_message(int(old_mid))
+            try:
+                await old_msg.delete()
+            except Exception:
+                pass
+        except Exception:
+            pass
+        LIST_RUNS_MSG_TO_SESSION.pop(int(old_mid), None)
+    try:
+        if f:
+            new_msg = await channel.send(embed=embed, file=f, view=view)
+        else:
+            new_msg = await channel.send(embed=embed, view=view)
+    except Exception:
+        return None
+    new_mid = int(new_msg.id)
+    data["control_message_id"] = new_mid
+    LIST_RUNS_MSG_TO_SESSION[new_mid] = str(session_id)
+    _register_list_views(str(session_id))
+    try:
+        if new_msg.embeds and new_msg.embeds[0].image and new_msg.embeds[0].image.url:
+            url = str(new_msg.embeds[0].image.url)
+            if not url.startswith("attachment://"):
+                data["image_url"] = url
+                embed_cdn, _ = await _render_list_embed(guild, data)
+                await new_msg.edit(embed=embed_cdn, view=view, attachments=[])
+    except Exception:
+        pass
+    return new_mid
+
+async def _maybe_repost_list_control(channel_id: int) -> None:
+    session_id = LIST_RUNS_BY_CHANNEL.get(int(channel_id))
+    if not session_id:
+        return
+    data = _list_session_data(session_id)
+    if not data or str(data.get("status")) == "done":
+        return
+    now = float(datetime.utcnow().timestamp())
+    last = float(LIST_REPOST_DEBOUNCE.get(int(channel_id), 0) or 0)
+    if (now - last) < 3.0:
+        return
+    LIST_REPOST_DEBOUNCE[int(channel_id)] = now
+    guild_id = data.get("guild_id")
+    guild = bot.get_guild(int(guild_id)) if guild_id else None  # type: ignore[arg-type]
+    if guild:
+        await _repost_list_to_bottom(guild, str(session_id))
+
+class ListConfirmView(discord.ui.View):
+    def __init__(self, session_id: str, uid: int):
+        super().__init__(timeout=None)
+        self.session_id = str(session_id)
+        self.uid = int(uid)
+        yes_btn = discord.ui.Button(
+            label="Yes",
+            style=discord.ButtonStyle.success,
+            custom_id=f"list_confirm_yes:{self.session_id}:{self.uid}",
+        )
+        yes_btn.callback = self._yes_callback  # type: ignore[method-assign]
+        self.add_item(yes_btn)
+        no_btn = discord.ui.Button(
+            label="Can't make it",
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"list_confirm_no:{self.session_id}:{self.uid}",
+        )
+        no_btn.callback = self._no_callback  # type: ignore[method-assign]
+        self.add_item(no_btn)
+
+    async def _yes_callback(self, interaction: discord.Interaction) -> None:
+        if interaction.user.id != self.uid:
+            await interaction.response.send_message("This DM button isn't for you.", ephemeral=True)
+            return
+        data = _list_session_data(self.session_id)
+        if not data or str(data.get("status")) == "done":
+            await interaction.response.send_message("This list run is no longer active.", ephemeral=True)
+            return
+        line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
+        declined: Set[int] = set(int(x) for x in (data.get("declined") or set()))  # type: ignore[arg-type]
+        if self.uid in line:
+            await interaction.response.send_message("You're already in line!", ephemeral=True)
+            return
+        if self.uid in declined:
+            declined.discard(self.uid)
+            data["declined"] = declined
+        line.append(self.uid)
+        data["line"] = line
+        await interaction.response.send_message("You're in line! We'll DM you when it's your turn.", ephemeral=True)
+        guild = interaction.client.get_guild(int(data.get("guild_id"))) if data.get("guild_id") else None  # type: ignore[arg-type]
+        if guild:
+            await _update_list_control_message(guild, self.session_id)
+
+    async def _no_callback(self, interaction: discord.Interaction) -> None:
+        if interaction.user.id != self.uid:
+            await interaction.response.send_message("This DM button isn't for you.", ephemeral=True)
+            return
+        data = _list_session_data(self.session_id)
+        if not data:
+            await interaction.response.send_message("This list run is no longer active.", ephemeral=True)
+            return
+        line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
+        declined: Set[int] = set(int(x) for x in (data.get("declined") or set()))  # type: ignore[arg-type]
+        if self.uid in line:
+            line = [x for x in line if int(x) != self.uid]
+            data["line"] = line
+            nxt = int(data.get("next_index", 0) or 0)
+            if nxt > len(line):
+                data["next_index"] = len(line)
+        declined.add(self.uid)
+        data["declined"] = declined
+        await interaction.response.send_message("No worries — skipped for this list run.", ephemeral=True)
+        guild = interaction.client.get_guild(int(data.get("guild_id"))) if data.get("guild_id") else None  # type: ignore[arg-type]
+        if guild:
+            await _update_list_control_message(guild, self.session_id)
+
+class ListControlView(discord.ui.View):
+    def __init__(self, session_id: str):
+        super().__init__(timeout=None)
+        self.session_id = str(session_id)
+        next_btn = discord.ui.Button(
+            label="Next",
+            style=discord.ButtonStyle.primary,
+            custom_id=f"list_next:{self.session_id}",
+        )
+        next_btn.callback = self._next_callback  # type: ignore[method-assign]
+        self.add_item(next_btn)
+        done_btn = discord.ui.Button(
+            label="Done",
+            style=discord.ButtonStyle.danger,
+            custom_id=f"list_done:{self.session_id}",
+        )
+        done_btn.callback = self._done_callback  # type: ignore[method-assign]
+        self.add_item(done_btn)
+
+    async def _next_callback(self, interaction: discord.Interaction) -> None:
+        data = _list_session_data(self.session_id)
+        if not data or str(data.get("status")) == "done":
+            await interaction.response.send_message("This list run is no longer active.", ephemeral=True)
+            return
+        if not _is_promoter_or_founder(interaction, data):
+            await interaction.response.send_message("Only the host or a founder can advance the list.", ephemeral=True)
+            return
+        await interaction.response.defer(ephemeral=True)
+        guild = interaction.guild
+        line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
+        next_index = int(data.get("next_index", 0) or 0)
+        group_size = max(1, int(data.get("group_size", 1) or 1))
+        waiting = line[next_index:]
+        if not waiting:
+            await interaction.followup.send("No one left in line.", ephemeral=True)
+            return
+        batch_players = waiting[:group_size]
+        new_index = next_index + len(batch_players)
+        data["next_index"] = new_index
+        sherpa_count = _list_run_sherpa_slots_needed(data, len(batch_players))
+        sherpas = _pick_sherpas_for_batch(guild, data, sherpa_count)
+        activity = str(data.get("activity") or "Activity")
+        batch_no = int(data.get("batch_number", 0) or 0) + 1
+        data["batch_number"] = batch_no
+        completed_batches: List[List[int]] = list(data.get("completed_batches") or [])  # type: ignore[arg-type]
+        completed_batches.append(list(batch_players))
+        data["completed_batches"] = completed_batches
+
+        sherpa_text = ", ".join(f"<@{uid}>" for uid in sherpas) if sherpas else "_None needed_"
+        player_text = ", ".join(f"<@{uid}>" for uid in batch_players)
+        channel_id = int(data.get("channel_id") or interaction.channel_id)
+        turn_msg = (
+            f"**Group {batch_no} — your turn for {activity}!**\n"
+            f"Players: {player_text}\n"
+            f"Sherpas: {sherpa_text}"
+        )
+        await _send_to_channel_id(
+            channel_id,
+            content=turn_msg,
+            allowed_mentions=discord.AllowedMentions(users=True),
+        )
+
+        when_text = str(data.get("when_text") or "")
+        for uid in batch_players:
+            try:
+                member = guild.get_member(int(uid)) if guild else None
+                if not member:
+                    continue
+                dm = await member.create_dm()
+                await dm.send(
+                    content=(
+                        f"It's your turn for **{activity}**"
+                        + (f" at **{when_text}**" if when_text else "")
+                        + f" (Group {batch_no}).\nHead to the event channel!"
+                    )
+                )
+            except Exception:
+                pass
+
+        try:
+            act = str(data.get("activity") or "")
+            if act:
+                await _mark_queue_participants_checked(act, batch_players)
+        except Exception:
+            pass
+
+        await _update_list_control_message(guild, self.session_id)
+        await _repost_list_to_bottom(guild, self.session_id)
+        await interaction.followup.send(
+            f"Pulled group {batch_no}: {len(batch_players)} player(s)"
+            + (f" + {len(sherpas)} Sherpa(s)" if sherpas else "")
+            + ".",
+            ephemeral=True,
+        )
+
+    async def _done_callback(self, interaction: discord.Interaction) -> None:
+        data = _list_session_data(self.session_id)
+        if not data:
+            await interaction.response.send_message("This list run is no longer active.", ephemeral=True)
+            return
+        if not _is_promoter_or_founder(interaction, data):
+            await interaction.response.send_message("Only the host or a founder can end the list.", ephemeral=True)
+            return
+        data["status"] = "done"
+        channel_id = int(data.get("channel_id") or 0)
+        if channel_id:
+            LIST_RUNS_BY_CHANNEL.pop(channel_id, None)
+        guild = interaction.guild
+        embed, _ = await _render_list_embed(guild, data)
+        try:
+            await interaction.response.edit_message(embed=embed, view=None)
+        except Exception:
+            await interaction.response.send_message("List run ended.", ephemeral=True)
+
+# ---------------------------
 # DM Confirm Views
 # ---------------------------
 
@@ -4608,6 +5035,244 @@ async def schedule_cmd(
                 pass
 
 # ---------------------------
+# /list — marathon list run (batch queue with Next/Done controls)
+# ---------------------------
+
+@bot.tree.command(
+    name="list",
+    description="(Founder) Start a back-to-back list run: DM queue, line up players, pull groups with Next/Done",
+)
+@founder_only()
+@app_commands.describe(
+    activity="Activity name",
+    datetime_str="Date and time (MM-DD HH:MM, 24h)",
+    timezone="Timezone (dropdown)",
+    group_size="Players per group (e.g. 3 pulls 3 at a time)",
+    difficulty="Difficulty (raids/dungeons only)",
+    sherpas="User(s) to pre-slot as Sherpa helpers (optional)",
+)
+@app_commands.autocomplete(activity=_activity_autocomplete)
+@app_commands.choices(
+    timezone=[
+        app_commands.Choice(name="US Eastern", value="America/New_York"),
+        app_commands.Choice(name="US Central", value="America/Chicago"),
+        app_commands.Choice(name="US Mountain", value="America/Denver"),
+        app_commands.Choice(name="US Pacific", value="America/Los_Angeles"),
+        app_commands.Choice(name="UTC", value="UTC"),
+        app_commands.Choice(name="Europe/London", value="Europe/London"),
+        app_commands.Choice(name="Europe/Paris", value="Europe/Paris"),
+        app_commands.Choice(name="Asia/Tokyo", value="Asia/Tokyo"),
+    ],
+    difficulty=[
+        app_commands.Choice(name="Normal", value="Normal"),
+        app_commands.Choice(name="Master", value="Master"),
+    ],
+)
+async def list_cmd(
+    interaction: discord.Interaction,
+    activity: str,
+    datetime_str: str,
+    timezone: str = "America/New_York",
+    group_size: int = 3,
+    difficulty: Optional[str] = None,
+    sherpas: Optional[str] = None,
+):
+    try:
+        await interaction.response.defer(ephemeral=True)
+    except Exception:
+        pass
+
+    try:
+        act, sug = _resolve_activity(activity)
+        if not act:
+            hint = (" Try: " + ", ".join(sug)) if sug else ""
+            await interaction.followup.send(f"Unknown activity.{hint}", ephemeral=True)
+            return
+
+        is_raid_dungeon = _is_raid_or_dungeon(act)
+        selected_difficulty = difficulty if is_raid_dungeon else None
+        channel_id = int(EVENT_SIGNUP_CHANNEL_ID or interaction.channel_id)
+        cap = _cap_for_activity(act)
+        batch_players = max(1, min(int(group_size or 1), cap))
+
+        try:
+            await load_queues()
+        except Exception:
+            pass
+
+        queue_members = [int(uid) for uid in (QUEUES.get(act, []) or [])]
+        if not queue_members:
+            await interaction.followup.send(
+                f"No one is on the queue for **{act}**. Use /join first.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            date_part, time_part = datetime_str.strip().split()
+            year = datetime.now().year
+            date_full = f"{year}-{date_part}"
+        except Exception:
+            await interaction.followup.send("Invalid datetime format. Use MM-DD HH:MM.", ephemeral=True)
+            return
+
+        start_ts = _parse_date_time_to_epoch(date_full, time_part, tz_name=timezone)
+        if not start_ts:
+            await interaction.followup.send(
+                "Could not parse the date/time. Use MM-DD HH:MM (24h).",
+                ephemeral=True,
+            )
+            return
+        when_text = f"<t:{start_ts}:F> ({timezone})"
+
+        guild = interaction.guild
+        sherpa_ids = _parse_user_ids(sherpas or "", guild) if sherpas else []
+        sherpa_pool: List[int] = []
+        seen_sherpas: Set[int] = set()
+        for sid in sherpa_ids:
+            if sid not in seen_sherpas:
+                sherpa_pool.append(int(sid))
+                seen_sherpas.add(int(sid))
+
+        existing_session = LIST_RUNS_BY_CHANNEL.get(channel_id)
+        if existing_session:
+            old = _list_session_data(existing_session)
+            if old and str(old.get("status")) != "done":
+                old["status"] = "done"
+                old_mid = _list_control_message_id(old)
+                if guild and old_mid:
+                    try:
+                        ch = guild.get_channel(channel_id) or await guild.fetch_channel(channel_id)
+                        if ch:
+                            msg = await ch.fetch_message(int(old_mid))
+                            emb, _ = await _render_list_embed(guild, old)
+                            await msg.edit(embed=emb, view=None)
+                    except Exception:
+                        pass
+
+        session_id = uuid.uuid4().hex[:12]
+        promoter_id = interaction.user.id
+        data: Dict[str, object] = {
+            "session_id": session_id,
+            "guild_id": guild.id if guild else None,
+            "activity": act,
+            "when_text": when_text,
+            "start_ts": start_ts,
+            "timezone": timezone,
+            "difficulty": selected_difficulty,
+            "capacity": cap,
+            "group_size": batch_players,
+            "channel_id": channel_id,
+            "promoter_id": promoter_id,
+            "line": [],
+            "declined": set(),
+            "next_index": 0,
+            "completed_batches": [],
+            "sherpa_pool": sherpa_pool,
+            "sherpa_index": 0,
+            "status": "active",
+            "batch_number": 0,
+            "sherpa_alert_message_id": None,
+            "sherpa_alert_channel_id": None,
+        }
+        LIST_SESSIONS[session_id] = data
+        LIST_RUNS_BY_CHANNEL[channel_id] = session_id
+
+        embed, f = await _render_list_embed(guild, data)
+        view = ListControlView(session_id=session_id)
+        if f:
+            ctrl_msg = await _send_to_channel_id(channel_id, embed=embed, file=f, view=view)
+        else:
+            ctrl_msg = await _send_to_channel_id(channel_id, embed=embed, view=view)
+        if not ctrl_msg:
+            LIST_SESSIONS.pop(session_id, None)
+            LIST_RUNS_BY_CHANNEL.pop(channel_id, None)
+            await interaction.followup.send(
+                "Failed to post list control embed — set EVENT_SIGNUP_CHANNEL_ID or run in a channel.",
+                ephemeral=True,
+            )
+            return
+
+        mid = int(ctrl_msg.id)
+        data["control_message_id"] = mid
+        LIST_RUNS_MSG_TO_SESSION[mid] = session_id
+        _register_list_views(session_id)
+
+        try:
+            if ctrl_msg.embeds and ctrl_msg.embeds[0].image and ctrl_msg.embeds[0].image.url:
+                url = str(ctrl_msg.embeds[0].image.url)
+                if not url.startswith("attachment://"):
+                    data["image_url"] = url
+                    embed_cdn, _ = await _render_list_embed(guild, data)
+                    await ctrl_msg.edit(embed=embed_cdn, view=view, attachments=[])
+        except Exception:
+            pass
+
+        sherpa_slots = _list_run_sherpa_slots_needed(data, batch_players)
+        if RAID_SIGN_UP_CHANNEL_ID and sherpa_slots > 0:
+            try:
+                sherpa_embed = discord.Embed(
+                    title=f"🧭 Sherpa Signup — List Run: {act}",
+                    description=(
+                        f"We're running **{act}** back-to-back at {when_text}.\n"
+                        f"React ✅ to join the Sherpa rotation (fills remaining fireteam slots)."
+                    ),
+                    color=_activity_color(act),
+                )
+                sherpa_embed.add_field(name="When", value=when_text, inline=True)
+                sherpa_embed.add_field(name="List Control", value=f"[Jump to list]({ctrl_msg.jump_url})", inline=False)
+                alert = await _send_to_channel_id(int(RAID_SIGN_UP_CHANNEL_ID), embed=sherpa_embed)
+                if alert:
+                    data["sherpa_alert_message_id"] = str(alert.id)
+                    data["sherpa_alert_channel_id"] = str(alert.channel.id)
+                    try:
+                        await alert.add_reaction("✅")
+                    except Exception:
+                        pass
+            except Exception as e:
+                try:
+                    print("List sherpa signup post failed:", e)
+                except Exception:
+                    pass
+
+        sent = 0
+        for uid in queue_members:
+            try:
+                member = guild.get_member(uid) if guild else None
+                if not member:
+                    continue
+                dm = await member.create_dm()
+                await dm.send(
+                    content=(
+                        f"We're running **{act}** over and over today at **{when_text}** "
+                        f"in {guild.name if guild else 'the server'}.\n"
+                        "Tap **Yes** to get in line — we'll pull groups when it's your turn."
+                    ),
+                    view=ListConfirmView(session_id=session_id, uid=int(uid)),
+                )
+                _register_list_views(session_id, [int(uid)])
+                sent += 1
+            except Exception as e:
+                print("List DM failed:", e)
+
+        status_lines = [
+            f"Started list run for **{act}**" + (f" ({selected_difficulty})" if selected_difficulty else "") + ".",
+            f"DMed **{sent}** queued player(s).",
+            f"Control embed posted in <#{channel_id}> (stays at the bottom until **Done**).",
+            f"Group size: **{batch_players}** | Fireteam: **{cap}** | Sherpas per group: **{sherpa_slots}**.",
+        ]
+        if difficulty and not is_raid_dungeon:
+            status_lines.append("Difficulty ignored: only used for raids and dungeons.")
+        await interaction.followup.send("\n".join(status_lines), ephemeral=True)
+
+    except Exception as e:
+        print("/list command error:", e)
+        try:
+            await interaction.followup.send("An error occurred while starting the list run. Check the bot logs.", ephemeral=True)
+        except Exception:
+            pass
+
+# ---------------------------
 # /event — Player-Created Signup (with Sherpa Requests)
 # ---------------------------
 
@@ -4778,6 +5443,43 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
         return
     # Normalize emoji to string once
     emoji_str = str(payload.emoji)
+
+    # List-run Sherpa signup (✅ on sherpa alert for /list marathon)
+    for session_id, data in list(LIST_SESSIONS.items()):
+        if str(data.get("status")) == "done":
+            continue
+        alert_id = int(data.get("sherpa_alert_message_id")) if data.get("sherpa_alert_message_id") else None
+        alert_ch = int(data.get("sherpa_alert_channel_id")) if data.get("sherpa_alert_channel_id") else None
+        if not alert_id or payload.message_id != alert_id:
+            continue
+        if alert_ch is not None and payload.channel_id != alert_ch:
+            continue
+        if emoji_str != "✅":
+            continue
+        guild = bot.get_guild(payload.guild_id) if payload.guild_id else None
+        if not guild:
+            return
+        member = guild.get_member(payload.user_id)
+        if not member or not (_is_sherpa(member) or _is_sherpa_assistant(member)):
+            return
+        pool: List[int] = list(data.get("sherpa_pool") or [])  # type: ignore[arg-type]
+        if member.id not in pool:
+            pool.append(int(member.id))
+            data["sherpa_pool"] = pool
+        try:
+            dm = await member.create_dm()
+            activity = str(data.get("activity") or "Activity")
+            when_text = str(data.get("when_text") or "")
+            await dm.send(
+                content=(
+                    f"You're signed up as a Sherpa for the **{activity}** list run"
+                    + (f" at **{when_text}**" if when_text else "")
+                    + ". You'll be rotated in to fill fireteam slots."
+                )
+            )
+        except Exception:
+            pass
+        return
 
     # Sherpa alert claim (✅ or 🔁 on the sherpa signup message in RAID_SIGN_UP_CHANNEL)
     for mid, data in list(SCHEDULES.items()):

--- a/main.py
+++ b/main.py
@@ -3673,9 +3673,64 @@ def _parse_user_ids(text: str, guild: Optional[discord.Guild]) -> List[int]:
 # /list command — helpers & views (standalone; does not use SCHEDULES or ConfirmView)
 # ---------------------------
 
+LIST_JOIN_EMOJI = "✅"
+
 def _list_run_sherpa_slots_needed(data: Dict[str, object], player_count: int) -> int:
+    """Sherpa slots per group. Host always reserves 1 fireteam slot."""
     cap = int(data.get("capacity", 0) or 0)
-    return max(0, cap - int(player_count))
+    host_slots = 1 if data.get("host_in_fireteam", True) else 0
+    players = int(player_count)
+    room = max(0, cap - host_slots - players)
+    explicit = data.get("num_sherpas")
+    if explicit is not None:
+        return max(0, min(int(explicit), room))
+    return room
+
+def _list_max_group_size(data: Dict[str, object]) -> int:
+    """Max players pulled from the line per Next (host slot is separate)."""
+    cap = int(data.get("capacity", 0) or 0)
+    host_slots = 1 if data.get("host_in_fireteam", True) else 0
+    explicit = data.get("num_sherpas")
+    if explicit is not None:
+        return max(1, cap - host_slots - max(0, int(explicit)))
+    return max(1, cap - host_slots)
+
+async def _list_try_add_to_line(
+    guild: Optional[discord.Guild],
+    session_id: str,
+    uid: int,
+) -> Tuple[bool, str]:
+    data = _list_session_data(session_id)
+    if not data or str(data.get("status")) == "done":
+        return False, "This list is no longer active."
+    line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
+    if int(uid) in line:
+        return False, "You're already in line."
+    max_size = data.get("max_list_size")
+    if max_size is not None:
+        try:
+            limit = int(max_size)
+            if limit > 0 and len(line) >= limit:
+                return False, f"The list is full ({limit} max)."
+        except Exception:
+            pass
+    declined: Set[int] = set(int(x) for x in (data.get("declined") or set()))  # type: ignore[arg-type]
+    if int(uid) in declined:
+        declined.discard(int(uid))
+        data["declined"] = declined
+    line.append(int(uid))
+    data["line"] = line
+    if guild:
+        await _update_list_control_message(guild, session_id)
+    return True, "You're in line! We'll DM you when it's your turn."
+
+async def _list_add_join_reaction(message: Optional[discord.Message]) -> None:
+    if not message:
+        return
+    try:
+        await message.add_reaction(LIST_JOIN_EMOJI)
+    except Exception:
+        pass
 
 def _guild_sherpa_member_ids(guild: Optional[discord.Guild]) -> List[int]:
     if not guild:
@@ -3735,13 +3790,23 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
     completed_batches: List[List[int]] = list(data.get("completed_batches") or [])  # type: ignore[arg-type]
     host_id = data.get("host_id") or data.get("promoter_id")
 
+    max_list_size = data.get("max_list_size")
+    num_sherpas = data.get("num_sherpas")
+    host_in = bool(data.get("host_in_fireteam", True))
+
     title = f"📋 List — {activity}"
     if status == "done":
         desc = "This **/list** session is **finished**. Thanks everyone!"
     else:
+        sherpa_note = (
+            f"**{int(num_sherpas)}** Sherpa(s) per group"
+            if num_sherpas is not None
+            else "remaining slots filled with **Sherpas**"
+        )
         desc = (
             f"**/list** session for **{activity}** — running it back-to-back.\n"
-            f"Players go in groups of **{group_size}**; remaining fireteam slots are filled with **Sherpas**."
+            f"React {LIST_JOIN_EMOJI} on this post (or tap **Yes** in DMs) to join the line.\n"
+            f"Each group: **host** + **{group_size}** player(s) + {sherpa_note} (fireteam **{cap}**)."
         )
     embed = discord.Embed(title=title, description=desc, color=_activity_color(activity))
     embed.add_field(name="When", value=when, inline=False)
@@ -3749,6 +3814,20 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
         embed.add_field(name="Difficulty", value=str(data.get("difficulty")), inline=True)
     embed.add_field(name="Group Size", value=str(group_size), inline=True)
     embed.add_field(name="Fireteam Size", value=str(cap), inline=True)
+    if host_in:
+        embed.add_field(name="Host Slot", value="Yes (1 per group)", inline=True)
+    if num_sherpas is not None:
+        embed.add_field(name="Sherpas / Group", value=str(int(num_sherpas)), inline=True)
+    else:
+        embed.add_field(name="Sherpas / Group", value="Auto-fill", inline=True)
+    if max_list_size is not None:
+        try:
+            lim = int(max_list_size)
+            embed.add_field(name="List Cap", value=str(lim) if lim > 0 else "Unlimited", inline=True)
+        except Exception:
+            embed.add_field(name="List Cap", value="Unlimited", inline=True)
+    else:
+        embed.add_field(name="List Cap", value="Unlimited", inline=True)
     if host_id:
         embed.add_field(name="Hosted by", value=f"<@{int(host_id)}>", inline=True)
     embed.add_field(name="Batches Run", value=str(batch_no), inline=True)
@@ -3772,7 +3851,7 @@ async def _render_list_embed(guild: Optional[discord.Guild], data: Dict[str, obj
         )
 
     if status == "active":
-        embed.set_footer(text="List command • Next pulls the next group (cycles the line) • Done ends this list")
+        embed.set_footer(text=f"React {LIST_JOIN_EMOJI} to join • Next pulls the next group • Done ends this list")
 
     try:
         img_url = data.get("image_url")
@@ -3858,6 +3937,7 @@ async def _repost_list_to_bottom(guild: Optional[discord.Guild], session_id: str
             new_msg = await channel.send(embed=embed, view=view)
     except Exception:
         return None
+    await _list_add_join_reaction(new_msg)
     new_mid = int(new_msg.id)
     data["control_message_id"] = new_mid
     LIST_RUNS_MSG_TO_SESSION[new_mid] = str(session_id)
@@ -3918,20 +3998,9 @@ class ListConfirmView(discord.ui.View):
         if not data or str(data.get("status")) == "done":
             await interaction.response.send_message("This list run is no longer active.", ephemeral=True)
             return
-        line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
-        declined: Set[int] = set(int(x) for x in (data.get("declined") or set()))  # type: ignore[arg-type]
-        if self.uid in line:
-            await interaction.response.send_message("You're already in line!", ephemeral=True)
-            return
-        if self.uid in declined:
-            declined.discard(self.uid)
-            data["declined"] = declined
-        line.append(self.uid)
-        data["line"] = line
-        await interaction.response.send_message("You're in line! We'll DM you when it's your turn.", ephemeral=True)
         guild = interaction.client.get_guild(int(data.get("guild_id"))) if data.get("guild_id") else None  # type: ignore[arg-type]
-        if guild:
-            await _update_list_control_message(guild, self.session_id)
+        ok, msg = await _list_try_add_to_line(guild, self.session_id, self.uid)
+        await interaction.response.send_message(msg, ephemeral=True)
 
     async def _no_callback(self, interaction: discord.Interaction) -> None:
         if interaction.user.id != self.uid:
@@ -3986,32 +4055,28 @@ class ListControlView(discord.ui.View):
         await interaction.response.defer(ephemeral=True)
         guild = interaction.guild
         line: List[int] = list(data.get("line") or [])  # type: ignore[arg-type]
-        if not line:
-            await interaction.followup.send(
-                "No one has joined the line yet. Players tap **Yes** in their DMs first.",
-                ephemeral=True,
-            )
-            return
-
         next_index = int(data.get("next_index", 0) or 0)
-        group_size = max(1, int(data.get("group_size", 1) or 1))
-        waiting = line[next_index:]
+        group_size = max(1, min(int(data.get("group_size", 1) or 1), _list_max_group_size(data)))
+        host_id = int(data.get("host_id") or 0)
         wrapped_round = False
-        if not waiting:
-            # End of line — start another lap so Next can be used over and over
-            data["next_index"] = 0
-            data["round_number"] = int(data.get("round_number", 1) or 1) + 1
-            next_index = 0
-            waiting = line[:]
-            wrapped_round = True
-
-        batch_players = waiting[:group_size]
-        new_index = next_index + len(batch_players)
-        # If this batch finishes the line, next click wraps to round+1
-        if new_index >= len(line):
-            data["next_index"] = len(line)
+        waiting: List[int] = []
+        if line:
+            waiting = line[next_index:]
+            if not waiting:
+                data["next_index"] = 0
+                data["round_number"] = int(data.get("round_number", 1) or 1) + 1
+                next_index = 0
+                waiting = line[:]
+                wrapped_round = True
+            batch_players = waiting[:group_size]
+            new_index = next_index + len(batch_players)
+            if new_index >= len(line):
+                data["next_index"] = len(line)
+            else:
+                data["next_index"] = new_index
         else:
-            data["next_index"] = new_index
+            batch_players = []
+
         sherpa_count = _list_run_sherpa_slots_needed(data, len(batch_players))
         sherpas = _pick_sherpas_for_batch(guild, data, sherpa_count)
         activity = str(data.get("activity") or "Activity")
@@ -4021,11 +4086,13 @@ class ListControlView(discord.ui.View):
         completed_batches.append(list(batch_players))
         data["completed_batches"] = completed_batches
 
-        sherpa_text = ", ".join(f"<@{uid}>" for uid in sherpas) if sherpas else "_None needed_"
-        player_text = ", ".join(f"<@{uid}>" for uid in batch_players)
+        host_text = f"<@{host_id}>" if host_id else "_None_"
+        sherpa_text = ", ".join(f"<@{uid}>" for uid in sherpas) if sherpas else "_None_"
+        player_text = ", ".join(f"<@{uid}>" for uid in batch_players) if batch_players else "_None_"
         channel_id = int(data.get("channel_id") or interaction.channel_id)
         turn_msg = (
             f"**Group {batch_no} — your turn for {activity}!**\n"
+            f"Host: {host_text}\n"
             f"Players: {player_text}\n"
             f"Sherpas: {sherpa_text}"
         )
@@ -4056,9 +4123,11 @@ class ListControlView(discord.ui.View):
         round_no = int(data.get("round_number", 1) or 1)
         lap_note = f" (round {round_no})" if wrapped_round else ""
         await interaction.followup.send(
-            f"Pulled group {batch_no}{lap_note}: {len(batch_players)} player(s)"
+            f"Pulled group {batch_no}{lap_note}: host"
+            + (f" + {len(batch_players)} player(s)" if batch_players else "")
             + (f" + {len(sherpas)} Sherpa(s)" if sherpas else "")
-            + ". Hit **Next** again whenever you're ready for the next group.",
+            + f" = {1 + len(batch_players) + len(sherpas)}/{int(data.get('capacity', 0))} fireteam."
+            + " Hit **Next** again whenever you're ready.",
             ephemeral=True,
         )
 
@@ -5075,7 +5144,9 @@ async def schedule_cmd(
     activity="Activity name",
     datetime_str="Date and time (MM-DD HH:MM, 24h)",
     timezone="Timezone (dropdown)",
-    group_size="Players per group (e.g. 3 pulls 3 at a time)",
+    group_size="Players pulled from the line per group (host uses 1 slot)",
+    num_sherpas="Sherpas per group (leave empty to auto-fill remaining fireteam slots)",
+    max_list_size="Max people allowed in the line (leave empty for unlimited)",
     difficulty="Difficulty (raids/dungeons only)",
     sherpas="User(s) to pre-slot as Sherpa helpers (optional)",
 )
@@ -5102,6 +5173,8 @@ async def list_cmd(
     datetime_str: str,
     timezone: str = "America/New_York",
     group_size: int = 3,
+    num_sherpas: Optional[int] = None,
+    max_list_size: Optional[int] = None,
     difficulty: Optional[str] = None,
     sherpas: Optional[str] = None,
 ):
@@ -5121,7 +5194,22 @@ async def list_cmd(
         selected_difficulty = difficulty if is_raid_dungeon else None
         channel_id = int(EVENT_SIGNUP_CHANNEL_ID or interaction.channel_id)
         cap = _cap_for_activity(act)
-        batch_players = max(1, min(int(group_size or 1), cap))
+        host_slots = 1
+        sherpa_slots_fixed: Optional[int] = None
+        if num_sherpas is not None:
+            sherpa_slots_fixed = max(0, min(int(num_sherpas), max(0, cap - host_slots - 1)))
+        max_group = max(1, cap - host_slots - (sherpa_slots_fixed if sherpa_slots_fixed is not None else 0))
+        if sherpa_slots_fixed is None:
+            max_group = max(1, cap - host_slots)
+        batch_players = max(1, min(int(group_size or 1), max_group))
+        list_cap: Optional[int] = None
+        if max_list_size is not None:
+            try:
+                parsed_cap = int(max_list_size)
+                if parsed_cap > 0:
+                    list_cap = parsed_cap
+            except Exception:
+                list_cap = None
 
         try:
             await load_queues()
@@ -5129,12 +5217,6 @@ async def list_cmd(
             pass
 
         queue_members = [int(uid) for uid in (QUEUES.get(act, []) or [])]
-        if not queue_members:
-            await interaction.followup.send(
-                f"No one is on the queue for **{act}**. Use /join first.",
-                ephemeral=True,
-            )
-            return
 
         try:
             date_part, time_part = datetime_str.strip().split()
@@ -5191,6 +5273,9 @@ async def list_cmd(
             "difficulty": selected_difficulty,
             "capacity": cap,
             "group_size": batch_players,
+            "num_sherpas": sherpa_slots_fixed,
+            "max_list_size": list_cap,
+            "host_in_fireteam": True,
             "channel_id": channel_id,
             "host_id": host_id,
             "line": [],
@@ -5227,6 +5312,7 @@ async def list_cmd(
         data["control_message_id"] = mid
         LIST_RUNS_MSG_TO_SESSION[mid] = session_id
         _register_list_views(session_id)
+        await _list_add_join_reaction(ctrl_msg)
 
         try:
             if ctrl_msg.embeds and ctrl_msg.embeds[0].image and ctrl_msg.embeds[0].image.url:
@@ -5239,7 +5325,7 @@ async def list_cmd(
             pass
 
         sherpa_slots = _list_run_sherpa_slots_needed(data, batch_players)
-        if RAID_SIGN_UP_CHANNEL_ID and sherpa_slots > 0:
+        if RAID_SIGN_UP_CHANNEL_ID and sherpa_slots > 0 and sherpa_slots_fixed is None:
             try:
                 sherpa_embed = discord.Embed(
                     title=f"🧭 Sherpa Signup — /list: {act}",
@@ -5287,9 +5373,18 @@ async def list_cmd(
 
         status_lines = [
             f"**/list** started for **{act}**" + (f" ({selected_difficulty})" if selected_difficulty else "") + ".",
-            f"DMed **{sent}** queued player(s) to join the line.",
+            f"DMed **{sent}** queued player(s). Anyone can also react {LIST_JOIN_EMOJI} on the list post to join.",
             f"List embed posted in <#{channel_id}> (stays at the bottom until **Done**).",
-            f"Group size: **{batch_players}** | Fireteam: **{cap}** | Sherpas per group: **{sherpa_slots}**.",
+            (
+                f"Per group: **1 host** + **{batch_players}** player(s)"
+                + (
+                    f" + **{sherpa_slots_fixed}** Sherpa(s)"
+                    if sherpa_slots_fixed is not None
+                    else f" + **{sherpa_slots}** Sherpa(s) auto-fill"
+                )
+                + f" = **{cap}** fireteam."
+            ),
+            f"List cap: **{'unlimited' if list_cap is None else list_cap}**.",
         ]
         if difficulty and not is_raid_dungeon:
             status_lines.append("Difficulty ignored: only used for raids and dungeons.")
@@ -5473,6 +5568,32 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
         return
     # Normalize emoji to string once
     emoji_str = str(payload.emoji)
+
+    # /list — anyone reacts ✅ on the control embed to join the line
+    session_id = LIST_RUNS_MSG_TO_SESSION.get(int(payload.message_id))
+    if session_id and emoji_str == LIST_JOIN_EMOJI:
+        data = _list_session_data(str(session_id))
+        if data and str(data.get("type")) == "list_run" and str(data.get("status")) != "done":
+            guild = bot.get_guild(payload.guild_id) if payload.guild_id else None
+            if not guild:
+                return
+            member = guild.get_member(payload.user_id)
+            if not member:
+                return
+            ok, msg = await _list_try_add_to_line(guild, str(session_id), int(member.id))
+            if not ok:
+                try:
+                    dm = await member.create_dm()
+                    await dm.send(content=f"Could not join the **/list** line: {msg}")
+                except Exception:
+                    pass
+            else:
+                try:
+                    dm = await member.create_dm()
+                    await dm.send(content=msg)
+                except Exception:
+                    pass
+            return
 
     # /list Sherpa signup (✅ on sherpa alert — separate from /schedule sherpa posts)
     for session_id, data in list(LIST_SESSIONS.items()):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a standalone **`/list`** command — separate from `/schedule` — for running an activity on repeat with batched queue pulls.

## `/list` vs `/schedule`

| | `/list` | `/schedule` |
|---|---------|-------------|
| Purpose | Repeat runs, one line, Next/Done batches | One scheduled event with roster + reminders |
| Storage | `LIST_SESSIONS` (`type: list_run`) | `SCHEDULES` |
| DM buttons | `ListConfirmView` (Yes / Can't make it) | `ConfirmView` (Confirm / Can't make it) |
| Channel control | Embed with **Next** + **Done** buttons | Event embed + reactions |
| Queue ✅ marks | Does **not** mark queue checked | Marks checked when confirmed |
| Host permission | `_is_list_host_or_founder` | `_is_promoter_or_founder` |

## What `/list` does

- DMs everyone on the activity queue — **Yes** joins the line
- Posts a list control embed to the event signup channel
- **Next** pulls `group_size` players, fills remaining slots with Sherpas, mentions + DMs them
- **Done** ends the session; embed stays at bottom until then
- Optional Sherpa signup post for the Sherpa rotation pool

## Options

`activity`, `datetime_str`, `timezone`, `group_size`, `difficulty`, `sherpas`

## Testing

- `python3 -m py_compile main.py` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3a2cb0-dc65-438f-a2c4-7eaba9067211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3a2cb0-dc65-438f-a2c4-7eaba9067211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

